### PR TITLE
fix: include @types/debug in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "debug": "^4.2.0",
+    "@types/debug": "^4.1.5",
     "got": "^11.7.0",
     "jsonwebtoken": "^8.5.1",
     "node-cache": "^5.1.2",
@@ -29,7 +30,6 @@
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
-    "@types/debug": "^4.1.5",
     "@types/jsonwebtoken": "^8.5.0",
     "@types/mocha": "^8.0.3",
     "@types/node": "^14.11.2",


### PR DESCRIPTION
We re-export one of the types from the debug module. This meant that people using
node-apps-toolkit would have to add the @types/debug dependency to their project!