### PR TITLE
chore: exclude dependabot from checked commits

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,4 +1,4 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
-  ignores: [(msg) => msg.startsWith('chore(deps')],
+  defaultIgnores: true,
 }

--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  ignores: [(msg) => msg.startsWith('chore(deps)') || msg.startsWith('chore(deps-dev)')],
+}

--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,4 +1,4 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
-  defaultIgnores: true,
+  ignores: [(msg) => msg.includes('Signed-off-by: dependabot[bot]')],
 }

--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,4 +1,4 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
-  ignores: [(msg) => msg.startsWith('chore(deps)') || msg.startsWith('chore(deps-dev)')],
+  ignores: [(msg) => msg.startsWith('chore(deps')],
 }

--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "@commitlint/config-conventional"
-  ]
-}


### PR DESCRIPTION
This should work as long as dependabot does not change name or the convention around signed-off commits stays the same