### PR TITLE
fix: include spaceId as part of cacheKey

### DIFF
--- a/src/keys/get-management-token.spec.ts
+++ b/src/keys/get-management-token.spec.ts
@@ -85,7 +85,7 @@ describe('getManagementToken', () => {
     assert.strictEqual(result, mockToken)
 
     // Overwrite TTL expiry to 5ms
-    const cacheKey = APP_ID + ENVIRONMENT_ID + PRIVATE_KEY.slice(32, 132)
+    const cacheKey = APP_ID + SPACE_ID + ENVIRONMENT_ID + PRIVATE_KEY.slice(32, 132)
     cache.set(cacheKey, result, 0.005)
 
     // Sleep 10ms

--- a/src/keys/get-management-token.ts
+++ b/src/keys/get-management-token.ts
@@ -87,7 +87,8 @@ export const createGetManagementToken = (log: Logger, http: HttpClient, cache: N
       opts.reuseToken = true
     }
 
-    const cacheKey = opts.appInstallationId + opts.environmentId + privateKey.slice(32, 132)
+    const cacheKey =
+      opts.appInstallationId + opts.spaceId + opts.environmentId + privateKey.slice(32, 132)
     if (opts.reuseToken) {
       const existing = cache.get(cacheKey) as string
       if (existing) {


### PR DESCRIPTION
I'm currently unable to use the cache because I am making requests against multiple spaces.  Not sure if there is a reason `spaceId` wasn't included in the cacheKey but this would solve that issue for me.