### PR TITLE
feat: update delivery function handler interface

### DIFF
--- a/src/requests/typings/deliveryFunction.ts
+++ b/src/requests/typings/deliveryFunction.ts
@@ -8,6 +8,7 @@ export enum DeliveryFunctionRequestEventType {
 }
 
 export type GraphQLFieldTypeMappingRequest = {
+  type: DeliveryFunctionRequestEventType.GRAPHQL_FIELD_MAPPING
   fields: { contentTypeId: string; field: Field }[]
 }
 
@@ -27,7 +28,9 @@ export type GraphQLFieldTypeMapping = {
 }
 
 export type GraphQLQueryRequest = {
+  type: DeliveryFunctionRequestEventType.GRAPHQL_QUERY
   query: string
+  isIntrospectionQuery: boolean
   variables: Record<string, unknown>
   operationName?: string
 }
@@ -51,12 +54,22 @@ export type DeliveryFunctionEventContext<P extends Record<string, any> = Record<
 }
 
 export type DeliveryFunctionEventHandlers = {
-  [DeliveryFunctionRequestEventType.GRAPHQL_FIELD_MAPPING]: (
-    event: GraphQLFieldTypeMappingRequest,
-    context: DeliveryFunctionEventContext
-  ) => Promise<GraphQLFieldTypeMappingResponse>
-  [DeliveryFunctionRequestEventType.GRAPHQL_QUERY]: (
-    event: GraphQLQueryRequest,
-    context: DeliveryFunctionEventContext
-  ) => Promise<GraphQLQueryResponse>
+  [DeliveryFunctionRequestEventType.GRAPHQL_FIELD_MAPPING]: {
+    event: GraphQLFieldTypeMappingRequest
+    response: GraphQLFieldTypeMappingResponse
+  }
+  [DeliveryFunctionRequestEventType.GRAPHQL_QUERY]: {
+    event: GraphQLQueryRequest
+    response: GraphQLQueryResponse
+  }
 }
+
+export type DeliveryFunctionEventHandler<
+  K extends keyof DeliveryFunctionEventHandlers = keyof DeliveryFunctionEventHandlers,
+  P extends Record<string, any> = Record<string, any>
+> = (
+  event: DeliveryFunctionEventHandlers[K]['event'],
+  context: DeliveryFunctionEventContext<P>
+) =>
+  | Promise<DeliveryFunctionEventHandlers[K]['response']>
+  | DeliveryFunctionEventHandlers[K]['response']

--- a/src/requests/typings/deliveryFunction.ts
+++ b/src/requests/typings/deliveryFunction.ts
@@ -2,13 +2,13 @@
 // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/ROADMAP.md
 /*eslint-disable no-unused-vars*/
 
-export enum DeliveryFunctionRequestEventType {
+export enum DeliveryFunctionEventType {
   GRAPHQL_FIELD_MAPPING = 'graphql.field.mapping',
   GRAPHQL_QUERY = 'graphql.query',
 }
 
-export type GraphQLFieldTypeMappingRequest = {
-  type: DeliveryFunctionRequestEventType.GRAPHQL_FIELD_MAPPING
+type GraphQLFieldTypeMappingRequest = {
+  type: DeliveryFunctionEventType.GRAPHQL_FIELD_MAPPING
   fields: { contentTypeId: string; field: Field }[]
 }
 
@@ -17,18 +17,21 @@ type Field = {
   type: string
 }
 
-export type GraphQLFieldTypeMappingResponse = GraphQLFieldTypeMapping[]
+export type GraphQLFieldTypeMappingResponse = {
+  namespace: string
+  fields: GraphQLFieldTypeMapping[]
+}
 
 export type GraphQLFieldTypeMapping = {
   contentTypeId: string
   fieldId: string
   graphQLOutputType: string
   graphQLQueryField: string
-  graphQLQueryArgument: string | Record<string, string>
+  graphQLQueryArguments: Record<string, string>
 }
 
-export type GraphQLQueryRequest = {
-  type: DeliveryFunctionRequestEventType.GRAPHQL_QUERY
+type GraphQLQueryRequest = {
+  type: DeliveryFunctionEventType.GRAPHQL_QUERY
   query: string
   isIntrospectionQuery: boolean
   variables: Record<string, unknown>
@@ -53,17 +56,24 @@ export type DeliveryFunctionEventContext<P extends Record<string, any> = Record<
   appInstallationParameters: P
 }
 
-export type DeliveryFunctionEventHandlers = {
-  [DeliveryFunctionRequestEventType.GRAPHQL_FIELD_MAPPING]: {
+type DeliveryFunctionEventHandlers = {
+  [DeliveryFunctionEventType.GRAPHQL_FIELD_MAPPING]: {
     event: GraphQLFieldTypeMappingRequest
     response: GraphQLFieldTypeMappingResponse
   }
-  [DeliveryFunctionRequestEventType.GRAPHQL_QUERY]: {
+  [DeliveryFunctionEventType.GRAPHQL_QUERY]: {
     event: GraphQLQueryRequest
     response: GraphQLQueryResponse
   }
 }
 
+/**
+ * Event handler type that needs to be exported as `handler` from your delivery function.
+ * e.g. `const handler: DeliveryFunctionEventHandler = (event, context) => { ... }`
+ *
+ * This type can also be used to construct helper functions for specific events
+ * e.g. `const queryHandler: DeliveryFunctionEventHandler<'graphql.query'> = (event, context) => { ... }
+ */
 export type DeliveryFunctionEventHandler<
   K extends keyof DeliveryFunctionEventHandlers = keyof DeliveryFunctionEventHandlers,
   P extends Record<string, any> = Record<string, any>

--- a/src/requests/typings/deliveryFunction.ts
+++ b/src/requests/typings/deliveryFunction.ts
@@ -24,7 +24,7 @@ export type GraphQLFieldTypeMapping = {
   fieldId: string
   graphQLOutputType: string
   graphQLQueryField: string
-  graphQLQueryArgument: string
+  graphQLQueryArgument: string | Record<string, string>
 }
 
 export type GraphQLQueryRequest = {


### PR DESCRIPTION
In the PH on Tuesday we discussed the following changes
* Revert the handler map to a handler function using type unions
* Add a helper to make "type save" event handlers
* Add a `isIntrospectionQuery` boolean to the `graphql.query` event.
* Allow `GraphQLQueryArgument` to be a `Record<string, string>` to allow for multi-argument `GraphQLQueryField` calls. The record key would be the argument name, the key value a JSON Pointer (not set in stone, we might use a different string format) that points to the JSON property that needs to be extracted from the field value and provided as the argument value.