### PR TITLE
fix: export delivery function types [MONET-1440]

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,11 @@
 export { getManagementToken } from './keys'
 export { signRequest, verifyRequest, ContentfulHeader } from './requests'
 
-export type { AppActionCallContext, CanonicalRequest, SignedRequestHeaders } from './requests'
+export type {
+  AppActionCallContext,
+  CanonicalRequest,
+  SignedRequestHeaders,
+  DeliveryFunctionEventContext,
+  DeliveryFunctionEventHandler,
+  DeliveryFunctionEventType,
+} from './requests'

--- a/src/requests/index.ts
+++ b/src/requests/index.ts
@@ -4,6 +4,9 @@ export { ContentfulHeader, ContentfulContextHeader } from './typings'
 export type {
   AppActionCallContext,
   CanonicalRequest,
+  DeliveryFunctionEventContext,
+  DeliveryFunctionEventHandler,
+  DeliveryFunctionEventType,
   SignedRequestWithContextHeadersWithApp,
   SignedRequestWithContextHeadersWithUser,
   SignedRequestWithoutContextHeaders,


### PR DESCRIPTION
Current delivery function templates complain we're using unavailable code because the package does not export the types