### PR TITLE
fix: export as value and not type [MONET-1440]

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { getManagementToken } from './keys'
-export { signRequest, verifyRequest, ContentfulHeader } from './requests'
+export { signRequest, verifyRequest, ContentfulHeader, DeliveryFunctionEventType } from './requests'
 
 export type {
   AppActionCallContext,
@@ -7,5 +7,4 @@ export type {
   SignedRequestHeaders,
   DeliveryFunctionEventContext,
   DeliveryFunctionEventHandler,
-  DeliveryFunctionEventType,
 } from './requests'

--- a/src/requests/index.ts
+++ b/src/requests/index.ts
@@ -1,12 +1,11 @@
 export { signRequest } from './sign-request'
 export { verifyRequest } from './verify-request'
-export { ContentfulHeader, ContentfulContextHeader } from './typings'
+export { ContentfulHeader, ContentfulContextHeader, DeliveryFunctionEventType } from './typings'
 export type {
   AppActionCallContext,
   CanonicalRequest,
   DeliveryFunctionEventContext,
   DeliveryFunctionEventHandler,
-  DeliveryFunctionEventType,
   SignedRequestWithContextHeadersWithApp,
   SignedRequestWithContextHeadersWithUser,
   SignedRequestWithoutContextHeaders,


### PR DESCRIPTION
We were exporting delivery event as a type and then using it in the template as a value