### PR TITLE
feat: update AppActionCallContext type to reflect cmaHost

### DIFF
--- a/src/requests/typings/appAction.ts
+++ b/src/requests/typings/appAction.ts
@@ -7,5 +7,6 @@ export type AppActionCallContext = {
     environmentId: string
     appInstallationId: string
     userId: string
+    cmaHost: string
   }
 }


### PR DESCRIPTION
## Purpose

Hosted app actions include a `cmaHost` context value, which is used to instantiate a CMA client in the correct region. The typing for `AppActionCallContext` was not updated at the time, so the value isn't accessible in a type safe manner inside the HAA handler.

## Approach

* Add the value to the type. It's intentionally not specified as optional, which might be a smarter choice if HAAs had a larger adoption. Since they are internal only for now, I believe it's safe to assume that all HAAs have been updated and do include the `cmaHost`

