### PR TITLE
fix: set repository url 

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,9 @@
     "*.ts": [
       "npm run lint:fix"
     ]
+  },
+  "repository": {
+    "url": "github:contentful/node-apps-toolkit",
+    "type": "git"
   }
 }


### PR DESCRIPTION
[documentation for this package.json field](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#repository) 

tl;dr: 
> Specify the place where your code lives. This is helpful for people who want to contribute. If the git repo is on GitHub, then the npm docs command will be able to find you.

Without this, the CONTRIBUTING.md link fails when clicked via the npm homepage. 
