### PR TITLE
fix: clean up types by avoiding enums [MONET-1476]

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { getManagementToken } from './keys'
-export { signRequest, verifyRequest, ContentfulHeader, DeliveryFunctionEventType } from './requests'
+export { signRequest, verifyRequest, ContentfulHeader } from './requests'
 
 export type {
   AppActionCallContext,
@@ -7,4 +7,5 @@ export type {
   SignedRequestHeaders,
   DeliveryFunctionEventContext,
   DeliveryFunctionEventHandler,
+  DeliveryFunctionEventType,
 } from './requests'

--- a/src/requests/index.ts
+++ b/src/requests/index.ts
@@ -1,11 +1,12 @@
 export { signRequest } from './sign-request'
 export { verifyRequest } from './verify-request'
-export { ContentfulHeader, ContentfulContextHeader, DeliveryFunctionEventType } from './typings'
+export { ContentfulHeader, ContentfulContextHeader } from './typings'
 export type {
   AppActionCallContext,
   CanonicalRequest,
   DeliveryFunctionEventContext,
   DeliveryFunctionEventHandler,
+  DeliveryFunctionEventType,
   SignedRequestWithContextHeadersWithApp,
   SignedRequestWithContextHeadersWithUser,
   SignedRequestWithoutContextHeaders,

--- a/src/requests/typings/deliveryFunction.ts
+++ b/src/requests/typings/deliveryFunction.ts
@@ -2,13 +2,11 @@
 // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/ROADMAP.md
 /*eslint-disable no-unused-vars*/
 
-export enum DeliveryFunctionEventType {
-  GRAPHQL_FIELD_MAPPING = 'graphql.field.mapping',
-  GRAPHQL_QUERY = 'graphql.query',
-}
+const GRAPHQL_FIELD_MAPPING_EVENT = 'graphql.field.mapping'
+const GRAPHQL_QUERY_EVENT = 'graphql.query'
 
 type GraphQLFieldTypeMappingRequest = {
-  type: DeliveryFunctionEventType.GRAPHQL_FIELD_MAPPING
+  type: typeof GRAPHQL_FIELD_MAPPING_EVENT
   fields: { contentTypeId: string; field: Field }[]
 }
 
@@ -31,7 +29,7 @@ export type GraphQLFieldTypeMapping = {
 }
 
 type GraphQLQueryRequest = {
-  type: DeliveryFunctionEventType.GRAPHQL_QUERY
+  type: typeof GRAPHQL_QUERY_EVENT
   query: string
   isIntrospectionQuery: boolean
   variables: Record<string, unknown>
@@ -57,15 +55,17 @@ export type DeliveryFunctionEventContext<P extends Record<string, any> = Record<
 }
 
 type DeliveryFunctionEventHandlers = {
-  [DeliveryFunctionEventType.GRAPHQL_FIELD_MAPPING]: {
+  [GRAPHQL_FIELD_MAPPING_EVENT]: {
     event: GraphQLFieldTypeMappingRequest
     response: GraphQLFieldTypeMappingResponse
   }
-  [DeliveryFunctionEventType.GRAPHQL_QUERY]: {
+  [GRAPHQL_QUERY_EVENT]: {
     event: GraphQLQueryRequest
     response: GraphQLQueryResponse
   }
 }
+
+export type DeliveryFunctionEventType = keyof DeliveryFunctionEventHandlers
 
 /**
  * Event handler type that needs to be exported as `handler` from your delivery function.
@@ -75,7 +75,7 @@ type DeliveryFunctionEventHandlers = {
  * e.g. `const queryHandler: DeliveryFunctionEventHandler<'graphql.query'> = (event, context) => { ... }
  */
 export type DeliveryFunctionEventHandler<
-  K extends keyof DeliveryFunctionEventHandlers = keyof DeliveryFunctionEventHandlers,
+  K extends DeliveryFunctionEventType = DeliveryFunctionEventType,
   P extends Record<string, any> = Record<string, any>
 > = (
   event: DeliveryFunctionEventHandlers[K]['event'],


### PR DESCRIPTION
This way we can avoid the noise with 
```
const fieldMappingHandler: EventHandler<'graphql.field.mapping'> = (event, context) => {
...
}
```