### PR TITLE
fix: explicit support for node 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ The `node-apps-toolkit` is a growing collection of helpers and utilities for bui
 
 ## Compatibiltiy
 
-Requires an [Node.js LTS version](https://github.com/nodejs/Release). Odd-numbered and not-yet LTS major versions are not supported.
+Requires an [Node.js LTS version](https://github.com/nodejs/Release). Currently supported node versions:
+ - v18
+ - v20
+Odd-numbered and not-yet LTS major versions are not supported.
 
 ## Installation
  


### PR DESCRIPTION
bumping the package version to release previous commits that fixed support for node 18:
- https://github.com/contentful/node-apps-toolkit/pull/368
- https://github.com/contentful/node-apps-toolkit/commit/62a18e071b3a3bbe6ac13300945aec5dc2415dd2