### PR TITLE
fix: upgrade to latest contentful-management.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@types/debug": "^4.1.5",
-        "contentful-management": "^10.35.4",
+        "contentful-management": "^11.6.1",
         "debug": "^4.2.0",
         "got": "^11.7.0",
         "jsonwebtoken": "^9.0.0",
@@ -1752,9 +1752,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
-      "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -2443,20 +2443,20 @@
       }
     },
     "node_modules/contentful-management": {
-      "version": "10.46.3",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.46.3.tgz",
-      "integrity": "sha512-yhjJBfYAMnl/Yr8AC+o6RKfxxjjAtTWtzKtKBAdUxwdotbUxmmphT5NWfPwGrfq9NhixK70utSH/rt1kb15vDg==",
+      "version": "11.6.1",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.6.1.tgz",
+      "integrity": "sha512-ORocz/bupmrSUUcw5LAIL+RpabqALoDcqqb4KBC847uiFXfTrDkzLPEGuB46zR+8Fh08Lltz1tDw/TwRrXBVpQ==",
       "dependencies": {
         "@contentful/rich-text-types": "^16.3.0",
         "@types/json-patch": "0.0.30",
-        "axios": "^1.4.0",
+        "axios": "^1.6.2",
         "contentful-sdk-core": "^8.1.0",
         "fast-copy": "^3.0.0",
         "lodash.isplainobject": "^4.0.6",
         "type-fest": "^4.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/contentful-sdk-core": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "@types/debug": "^4.1.5",
-    "contentful-management": "^10.35.4",
+    "contentful-management": "^11.6.1",
     "debug": "^4.2.0",
     "got": "^11.7.0",
     "jsonwebtoken": "^9.0.0",


### PR DESCRIPTION
## Purpose

If we upgrade the app action CMA to https://github.com/contentful/app-upload-to-delivery/pull/269 then the type here https://github.com/contentful/node-apps-toolkit/blob/master/src/requests/typings/appAction.ts#L1 is out of whack with the type provided by the actual app action runtime.

This makes for annoying complaints in typescript, since typescript is aware of the discrepancy between the two different APIs.