### PR TITLE
fix: use node 20.8.1 for semantic-release in CICD []

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
       - vault/get-secrets:
           template-preset: "semantic-release-ecosystem"
       - node/install:
-          node-version: "18"
+          node-version: "20.8.1"
       - setup-npm
       - run: npm ci
       - run:


### PR DESCRIPTION
semantic-release requires node version >=20.8.1 