### PR TITLE
feat: add types for resource events [DANTE-1605]

### DIFF
--- a/src/requests/typings/function.ts
+++ b/src/requests/typings/function.ts
@@ -16,6 +16,14 @@ import {
   ScheduledActionProps,
   TaskProps,
 } from 'contentful-management'
+import {
+  RESOURCES_SEARCH_EVENT,
+  RESOURCES_LOOKUP_EVENT,
+  type ResourcesLookupRequest,
+  type ResourcesLookupResponse,
+  type ResourcesSearchRequest,
+  type ResourcesSearchResponse,
+} from './resources'
 
 const GRAPHQL_FIELD_MAPPING_EVENT = 'graphql.field.mapping'
 const GRAPHQL_QUERY_EVENT = 'graphql.query'
@@ -180,9 +188,22 @@ type FunctionEventHandlers = {
     event: AppEventRequest
     response: AppEventTransformationResponse
   }
+  [RESOURCES_SEARCH_EVENT]: {
+    event: ResourcesSearchRequest
+    response: ResourcesSearchResponse
+  }
+  [RESOURCES_LOOKUP_EVENT]: {
+    event: ResourcesLookupRequest
+    response: ResourcesLookupResponse
+  }
 }
 
-export type FunctionEvent = GraphQLFieldTypeMappingRequest | GraphQLQueryRequest | AppEventRequest
+export type FunctionEvent =
+  | GraphQLFieldTypeMappingRequest
+  | GraphQLQueryRequest
+  | AppEventRequest
+  | ResourcesSearchRequest
+  | ResourcesLookupRequest
 export type FunctionEventType = keyof FunctionEventHandlers
 
 /**

--- a/src/requests/typings/resources.ts
+++ b/src/requests/typings/resources.ts
@@ -1,0 +1,39 @@
+export const RESOURCES_SEARCH_EVENT = 'resources.search'
+export const RESOURCES_LOOKUP_EVENT = 'resources.lookup'
+
+export type ResourcesSearchRequest = {
+  type: 'resources.search'
+  resourceType: string
+  query: string
+  limit?: number
+  pages?: {
+    nextCursor: string
+  }
+}
+
+export type ResourcesSearchResponse<S extends Record<string, unknown> = Record<string, unknown>> = {
+  items: S[]
+  pages: {
+    nextCursor?: string
+  }
+}
+
+type Scalar = string | number | boolean
+
+export type ResourcesLookupRequest<L extends Record<string, Scalar[]> = Record<string, Scalar[]>> =
+  {
+    type: 'resources.lookup'
+    lookupBy: L
+    resourceType: string
+    limit?: number
+    pages?: {
+      nextCursor: string
+    }
+  }
+
+export type ResourcesLookupResponse<L extends Record<string, unknown> = Record<string, unknown>> = {
+  items: L[]
+  pages: {
+    nextCursor?: string
+  }
+}


### PR DESCRIPTION
Function events have been recently extended to support resources events (used in Extensible Resource Links), but all the types are so far only defined locally in `extensible-resource-links-example` example code. We want to unify the function types to cover the new events.