### PR TITLE
feat: better app action function types [EXT-5711]

### DIFF
--- a/src/requests/typings/appAction.ts
+++ b/src/requests/typings/appAction.ts
@@ -1,4 +1,4 @@
-import { PlainClientAPI } from 'contentful-management'
+import type { AppActionCategoryType, PlainClientAPI } from 'contentful-management'
 
 export type AppActionCallContext = {
   cma: PlainClientAPI
@@ -16,10 +16,13 @@ export type AppActionCustomCategoryBody = Record<string, unknown>
 export type AppActionEntriesV1CategoryBody = { entryIds: string }
 export type AppActionNotificationsV1CategoryBody = { message: string; recipient: string }
 
-export type AppActionCategory = 'Custom' | 'Entries.v1.0' | 'Notifications.v1.0'
-
 export type AppActionCategoryBodyMap = {
   Custom: AppActionCustomCategoryBody
   'Entries.v1.0': AppActionEntriesV1CategoryBody
   'Notifications.v1.0': AppActionNotificationsV1CategoryBody
 }
+
+export type AppActionRequestBody<CategoryType extends AppActionCategoryType> =
+  CategoryType extends keyof AppActionCategoryBodyMap
+    ? AppActionCategoryBodyMap[CategoryType]
+    : never

--- a/src/requests/typings/appAction.ts
+++ b/src/requests/typings/appAction.ts
@@ -11,3 +11,15 @@ export type AppActionCallContext = {
     uploadHost: string
   }
 }
+
+export type AppActionCustomSchemaBody = Record<string, unknown>
+export type AppActionEntriesV1SchemaBody = { entryIds: string }
+export type AppActionNotificationsV1SchemaBody = { message: string; recipient: string }
+
+export type AppActionSchema = 'Custom' | 'Entries.v1.0' | 'Notifications.v1.0'
+
+export type AppActionSchemaBodyMap = {
+  Custom: AppActionCustomSchemaBody
+  'Entries.v1.0': AppActionEntriesV1SchemaBody
+  'Notifications.v1.0': AppActionNotificationsV1SchemaBody
+}

--- a/src/requests/typings/appAction.ts
+++ b/src/requests/typings/appAction.ts
@@ -12,14 +12,14 @@ export type AppActionCallContext = {
   }
 }
 
-export type AppActionCustomSchemaBody = Record<string, unknown>
-export type AppActionEntriesV1SchemaBody = { entryIds: string }
-export type AppActionNotificationsV1SchemaBody = { message: string; recipient: string }
+export type AppActionCustomCategoryBody = Record<string, unknown>
+export type AppActionEntriesV1CategoryBody = { entryIds: string }
+export type AppActionNotificationsV1CategoryBody = { message: string; recipient: string }
 
-export type AppActionSchema = 'Custom' | 'Entries.v1.0' | 'Notifications.v1.0'
+export type AppActionCategory = 'Custom' | 'Entries.v1.0' | 'Notifications.v1.0'
 
-export type AppActionSchemaBodyMap = {
-  Custom: AppActionCustomSchemaBody
-  'Entries.v1.0': AppActionEntriesV1SchemaBody
-  'Notifications.v1.0': AppActionNotificationsV1SchemaBody
+export type AppActionCategoryBodyMap = {
+  Custom: AppActionCustomCategoryBody
+  'Entries.v1.0': AppActionEntriesV1CategoryBody
+  'Notifications.v1.0': AppActionNotificationsV1CategoryBody
 }

--- a/src/requests/typings/function.ts
+++ b/src/requests/typings/function.ts
@@ -24,6 +24,7 @@ import {
   type ResourcesSearchRequest,
   type ResourcesSearchResponse,
 } from './resources'
+import { AppActionSchema, AppActionSchemaBodyMap } from './appAction'
 
 const GRAPHQL_FIELD_MAPPING_EVENT = 'graphql.field.mapping'
 const GRAPHQL_QUERY_EVENT = 'graphql.query'
@@ -158,9 +159,9 @@ export type AppEventTransformationResponse = {
 
 export type AppEventHandlerResponse = void
 
-export type AppActionRequest = {
+export type AppActionRequest<S extends AppActionSchema = 'Custom'> = {
   headers: Record<string, string | number>
-  body: Record<string, unknown>
+  body: AppActionSchemaBodyMap[S]
   type: typeof APP_ACTION_CALL
 }
 
@@ -186,7 +187,7 @@ type FunctionEventHandlers = {
     response: GraphQLQueryResponse
   }
   [APP_ACTION_CALL]: {
-    event: AppActionRequest
+    event: AppActionRequest<keyof AppActionSchemaBodyMap>
     response: AppActionResponse
   }
   [APP_EVENT_FILTER]: {
@@ -214,6 +215,7 @@ type FunctionEventHandlers = {
 export type FunctionEvent =
   | GraphQLFieldTypeMappingRequest
   | GraphQLQueryRequest
+  | AppActionRequest
   | AppEventRequest
   | ResourcesSearchRequest
   | ResourcesLookupRequest

--- a/src/requests/typings/function.ts
+++ b/src/requests/typings/function.ts
@@ -159,9 +159,21 @@ export type AppEventTransformationResponse = {
 
 export type AppEventHandlerResponse = void
 
-export type AppActionRequest<S extends AppActionSchema = 'Custom'> = {
+/**
+ * The app action request body will contain different properties depending on the schema of the app action
+ *
+ * Specify your app action schema as the generic type `Schema` to get the correct body type,
+ * e.g. `const { body: { message, recipient }} = event as AppActionRequest<'Notification.v1.0'>`
+ *
+ * If you are using a Custom schema, you can specify its shape as the second generic type `CustomSchemaBody`,
+ * e.g. `const { body: { myNumber }} = event as AppActionRequest<'Custom', { myNumber: number }>`
+ */
+export type AppActionRequest<
+  Schema extends AppActionSchema = 'Custom',
+  CustomSchemaBody = AppActionSchemaBodyMap['Custom'],
+> = {
   headers: Record<string, string | number>
-  body: AppActionSchemaBodyMap[S]
+  body: Schema extends 'Custom' ? CustomSchemaBody : AppActionSchemaBodyMap[Schema]
   type: typeof APP_ACTION_CALL
 }
 
@@ -187,7 +199,7 @@ type FunctionEventHandlers = {
     response: GraphQLQueryResponse
   }
   [APP_ACTION_CALL]: {
-    event: AppActionRequest<keyof AppActionSchemaBodyMap>
+    event: AppActionRequest<AppActionSchema>
     response: AppActionResponse
   }
   [APP_EVENT_FILTER]: {
@@ -226,7 +238,7 @@ export type FunctionEventType = keyof FunctionEventHandlers
  * e.g. `const handler: FunctionEventHandler = (event, context) => { ... }`
  *
  * This type can also be used to construct helper functions for specific events
- * e.g. `const queryHandler: FunctionEventHandler<'graphql.query'> = (event, context) => { ... }
+ * e.g. `const queryHandler: FunctionEventHandler<'graphql.query'> = (event, context) => { ... }`
  */
 export type FunctionEventHandler<
   K extends FunctionEventType = FunctionEventType,

--- a/src/requests/typings/function.ts
+++ b/src/requests/typings/function.ts
@@ -24,7 +24,7 @@ import {
   type ResourcesSearchRequest,
   type ResourcesSearchResponse,
 } from './resources'
-import { AppActionSchema, AppActionSchemaBodyMap } from './appAction'
+import { AppActionCategory, AppActionCategoryBodyMap } from './appAction'
 
 const GRAPHQL_FIELD_MAPPING_EVENT = 'graphql.field.mapping'
 const GRAPHQL_QUERY_EVENT = 'graphql.query'
@@ -160,20 +160,20 @@ export type AppEventTransformationResponse = {
 export type AppEventHandlerResponse = void
 
 /**
- * The app action request body will contain different properties depending on the schema of the app action
+ * The app action request body will contain different properties depending on the category of the app action
  *
- * Specify your app action schema as the generic type `Schema` to get the correct body type,
+ * Specify your app action category as the generic type `Category` to get the correct body type,
  * e.g. `const { body: { message, recipient }} = event as AppActionRequest<'Notification.v1.0'>`
  *
- * If you are using a Custom schema, you can specify its shape as the second generic type `CustomSchemaBody`,
+ * If you are using the Custom category, you can specify the parameter shape as the second generic type `CustomCategoryBody`,
  * e.g. `const { body: { myNumber }} = event as AppActionRequest<'Custom', { myNumber: number }>`
  */
 export type AppActionRequest<
-  Schema extends AppActionSchema = 'Custom',
-  CustomSchemaBody = AppActionSchemaBodyMap['Custom'],
+  Category extends AppActionCategory = 'Custom',
+  CustomCategoryBody = AppActionCategoryBodyMap['Custom'],
 > = {
   headers: Record<string, string | number>
-  body: Schema extends 'Custom' ? CustomSchemaBody : AppActionSchemaBodyMap[Schema]
+  body: Category extends 'Custom' ? CustomCategoryBody : AppActionCategoryBodyMap[Category]
   type: typeof APP_ACTION_CALL
 }
 
@@ -199,7 +199,7 @@ type FunctionEventHandlers = {
     response: GraphQLQueryResponse
   }
   [APP_ACTION_CALL]: {
-    event: AppActionRequest<AppActionSchema>
+    event: AppActionRequest<AppActionCategory>
     response: AppActionResponse
   }
   [APP_EVENT_FILTER]: {

--- a/src/requests/typings/function.ts
+++ b/src/requests/typings/function.ts
@@ -3,6 +3,7 @@
 /*eslint-disable no-unused-vars*/
 
 import {
+  AppActionCategoryType,
   AppInstallationProps,
   AssetProps,
   BulkActionProps,
@@ -24,7 +25,7 @@ import {
   type ResourcesSearchRequest,
   type ResourcesSearchResponse,
 } from './resources'
-import { AppActionCategory, AppActionCategoryBodyMap } from './appAction'
+import { AppActionCategoryBodyMap, AppActionRequestBody } from './appAction'
 
 const GRAPHQL_FIELD_MAPPING_EVENT = 'graphql.field.mapping'
 const GRAPHQL_QUERY_EVENT = 'graphql.query'
@@ -160,7 +161,7 @@ export type AppEventTransformationResponse = {
 export type AppEventHandlerResponse = void
 
 /**
- * The app action request body will contain different properties depending on the category of the app action
+ * The app action request body will contain different parameters depending on the category of the app action
  *
  * Specify your app action category as the generic type `Category` to get the correct body type,
  * e.g. `const { body: { message, recipient }} = event as AppActionRequest<'Notification.v1.0'>`
@@ -169,11 +170,11 @@ export type AppEventHandlerResponse = void
  * e.g. `const { body: { myNumber }} = event as AppActionRequest<'Custom', { myNumber: number }>`
  */
 export type AppActionRequest<
-  Category extends AppActionCategory = 'Custom',
+  CategoryType extends AppActionCategoryType = 'Custom',
   CustomCategoryBody = AppActionCategoryBodyMap['Custom'],
 > = {
   headers: Record<string, string | number>
-  body: Category extends 'Custom' ? CustomCategoryBody : AppActionCategoryBodyMap[Category]
+  body: CategoryType extends 'Custom' ? CustomCategoryBody : AppActionRequestBody<CategoryType>
   type: typeof APP_ACTION_CALL
 }
 
@@ -199,7 +200,7 @@ type FunctionEventHandlers = {
     response: GraphQLQueryResponse
   }
   [APP_ACTION_CALL]: {
-    event: AppActionRequest<AppActionCategory>
+    event: AppActionRequest<AppActionCategoryType>
     response: AppActionResponse
   }
   [APP_EVENT_FILTER]: {


### PR DESCRIPTION
The body of an App Action Function request will include different properties based on what the Schema of the App Action is. This changeset allows Function developers to optionally specify the Schema of their App Action, giving them better information about what is available in the body of the request. Developers can also optionally provide their own types when using the `Custom` option. 