### PR TITLE
test: add retry header test

### DIFF
--- a/src/requests/sign-request.spec.ts
+++ b/src/requests/sign-request.spec.ts
@@ -177,6 +177,16 @@ describe('create-signature', () => {
       )
     })
 
+    it('generates different signatures with retried requests', () => {
+      const headers = { 'x-contentful-webhook-request-attempt': '1' }
+      const retryHeaders = { 'x-contentful-webhook-request-attempt': '2' }
+
+      assert.notStrictEqual(
+        signRequest(VALID_SECRET, { ...VALID_REQUEST, headers }, VALID_TIMESTAMP),
+        signRequest(VALID_SECRET, { ...VALID_REQUEST, headers: retryHeaders }, VALID_TIMESTAMP),
+      )
+    })
+
     it('does not return undefined headers', () => {
       const result = signRequest(VALID_SECRET, VALID_REQUEST, undefined)
 


### PR DESCRIPTION
adds a quick test to ensure different retries create different signatures. This is already working today and wanted some coverage for the future.