### PR TITLE
fix: app action request function event handler type [EXT-5710]

### DIFF
--- a/src/requests/typings/function.ts
+++ b/src/requests/typings/function.ts
@@ -190,7 +190,14 @@ export type FunctionEventContext<P extends Record<string, any> = Record<string, 
   cma?: PlainClientAPI
 }
 
-type FunctionEventHandlers = {
+/**
+ * T: Possibility to type app action category
+ * U: Possibility to type app action body (only applies to the Custom category)
+ */
+type FunctionEventHandlers<
+  T extends AppActionCategoryType = never,
+  U extends AppActionRequestBody<T> = never,
+> = {
   [GRAPHQL_FIELD_MAPPING_EVENT]: {
     event: GraphQLFieldTypeMappingRequest
     response: GraphQLFieldTypeMappingResponse
@@ -200,7 +207,7 @@ type FunctionEventHandlers = {
     response: GraphQLQueryResponse
   }
   [APP_ACTION_CALL]: {
-    event: AppActionRequest
+    event: AppActionRequest<T, U>
     response: AppActionResponse
   }
   [APP_EVENT_FILTER]: {

--- a/src/requests/typings/function.ts
+++ b/src/requests/typings/function.ts
@@ -200,7 +200,7 @@ type FunctionEventHandlers = {
     response: GraphQLQueryResponse
   }
   [APP_ACTION_CALL]: {
-    event: AppActionRequest<AppActionCategoryType>
+    event: AppActionRequest
     response: AppActionResponse
   }
   [APP_EVENT_FILTER]: {


### PR DESCRIPTION
We needed to add generics to `FunctionEventHandlers` in order to support someone defining specific types for the `AppActionCategory` and `AppActionRequestBody` when defining a function handler for an `appaction.call`. This will ultimately fix a type error we are seeing in our app action function example.