### PR TITLE
Update types of resources.search event

### DIFF
--- a/src/requests/typings/resources.ts
+++ b/src/requests/typings/resources.ts
@@ -6,6 +6,7 @@ export type ResourcesSearchRequest = {
   resourceType: string
   query: string
   limit?: number
+  locale?: string
   pages?: {
     nextCursor: string
   }

--- a/src/requests/typings/resources.ts
+++ b/src/requests/typings/resources.ts
@@ -4,8 +4,8 @@ export const RESOURCES_LOOKUP_EVENT = 'resources.lookup'
 export type ResourcesSearchRequest = {
   type: 'resources.search'
   resourceType: string
-  query: string
-  limit?: number
+  query?: string
+  limit: number
   locale?: string
   pages?: {
     nextCursor: string
@@ -26,7 +26,7 @@ export type ResourcesLookupRequest<L extends Record<string, Scalar[]> = Record<s
     type: 'resources.lookup'
     lookupBy: L
     resourceType: string
-    limit?: number
+    limit: number
     pages?: {
       nextCursor: string
     }


### PR DESCRIPTION
Align the types of the "resources.search" event to be the same as https://github.com/contentful/functions-api/pull/1177