### PR TITLE
feat: accurate TS types for each App Event payload type

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "build:docs": "typedoc --options .typedocrc.json src",
     "start:docs": "serve ./docs",
     "prepublishOnly": "npm run build && npm run build:docs",
-    "semantic-release": "semantic-release"
+    "semantic-release": "semantic-release",
+    "format": "prettier --write ./{src,test}/**/*.ts"
   },
   "author": "Contentful GmbH",
   "license": "MIT",
@@ -87,7 +88,8 @@
   },
   "lint-staged": {
     "*.ts": [
-      "npm run lint:fix"
+      "npm run lint:fix",
+      "npm run format"
     ]
   },
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ export { getManagementToken } from './keys'
 export { signRequest, verifyRequest, ContentfulHeader, ExpiredRequestException } from './requests'
 
 export type {
+  AppEventRequest,
+  AppEventPayloadMap,
   AppActionCallContext,
   CanonicalRequest,
   SignedRequestHeaders,
@@ -9,4 +11,5 @@ export type {
   FunctionEventHandler,
   FunctionEventType,
   FunctionEvent,
+  FunctionTypeEnum,
 } from './requests'

--- a/src/requests/index.ts
+++ b/src/requests/index.ts
@@ -3,12 +3,15 @@ export { signRequest } from './sign-request'
 export { verifyRequest } from './verify-request'
 export { ContentfulHeader, ContentfulContextHeader } from './typings'
 export type {
+  AppEventRequest,
+  AppEventPayloadMap,
   AppActionCallContext,
   CanonicalRequest,
   FunctionEvent,
   FunctionEventContext,
   FunctionEventHandler,
   FunctionEventType,
+  FunctionTypeEnum,
   SignedRequestWithContextHeadersWithApp,
   SignedRequestWithContextHeadersWithUser,
   SignedRequestWithoutContextHeaders,

--- a/src/requests/typings/event-payloads.ts
+++ b/src/requests/typings/event-payloads.ts
@@ -1,0 +1,353 @@
+import type {
+  CommentProps,
+  ContentTypeFieldValidation,
+  TaskProps,
+  Link,
+  ScheduledActionProps,
+  WorkflowProps,
+  EnvironmentTemplateInstallationProps,
+  BulkActionProps,
+  AppInstallationProps,
+  ReleaseActionProps,
+  ReleaseProps,
+} from 'contentful-management'
+
+export type AppEventPayloadMap = {
+  Entry: {
+    create: EntryCreateEventPayload
+    save: EntrySaveEventPayload
+    auto_save: EntryAutosaveEventPayload
+    publish: EntryPublishEventPayload
+    unpublish: EntryUnpublishEventPayload
+    archive: EntryArchiveEventPayload
+    unarchive: EntryUnarchiveEventPayload
+    delete: EntryDeleteEventPayload
+  }
+  Asset: {
+    create: AssetCreateEventPayload
+    save: AssetSaveEventPayload
+    auto_save: AssetAutosaveEventPayload
+    publish: AssetPublishEventPayload
+    unpublish: AssetUnpublishEventPayload
+    archive: AssetArchiveEventPayload
+    unarchive: AssetUnarchiveEventPayload
+    delete: AssetDeleteEventPayload
+  }
+  ContentType: {
+    create: ContentTypeCreateEventPayload
+    save: ContentTypeSaveEventPayload
+    publish: ContentTypePublishEventPayload
+    unpublish: ContentTypeUnpublishEventPayload
+    delete: ContentTypeDeleteEventPayload
+  }
+  Comment: {
+    create: CreateCommentEventPayload
+    delete: DeleteCommentEventPayload
+  }
+  Task: {
+    create: CreateTaskEventPayload
+    save: SaveTaskEventPayload
+    delete: DeleteTaskEventPayload
+  }
+  AppInstallation: {
+    create: AppInstallationProps
+    save: AppInstallationProps
+    delete: AppInstallationProps
+  }
+  Release: {
+    create: ReleaseProps
+    save: ReleaseProps
+    delete: ReleaseProps
+  }
+  ReleaseAction: {
+    create: ReleaseActionProps
+    execute: ReleaseActionProps
+  }
+  ScheduledAction: {
+    create: ScheduledActionProps
+    save: ScheduledActionProps
+    delete: ScheduledActionProps
+    execute: ScheduledActionProps
+  }
+  BulkAction: {
+    create: BulkActionProps
+    execute: BulkActionProps
+  }
+  TemplateInstallation: {
+    complete: EnvironmentTemplateInstallationProps
+  }
+  Workflow: {
+    create: WorkflowProps
+    save: WorkflowProps
+    delete: WorkflowProps
+  }
+}
+
+/* Common */
+
+interface Metadata {
+  tags: Link<'Tag'>[]
+  concepts: Link<'TaxonomyConcept'>[]
+}
+
+interface BasePublishableEntitySys<T extends 'Entry' | 'Asset' | 'ContentType'> {
+  space: Link<'Space'>
+  id: string
+  type: T
+  createdAt: string
+  updatedAt: string
+  environment: Link<'Environment'>
+  createdBy: Link<'User'>
+  updatedBy: Link<'User'>
+  publishedCounter: number
+  version: number
+  urn: string
+}
+
+interface BasePublishableDeliveryEntitySys<T extends 'Entry' | 'Asset'>
+  extends BasePublishableEntitySys<T> {
+  fieldStatus: {
+    '*': {
+      [locale: string]: string
+    }
+  }
+  automationTags: any[]
+}
+
+interface PublishedEntityAutosaveEventSysProps {
+  publishedVersion: number
+  publishedAt: string
+  firstPublishedAt: string
+  publishedBy: Link<'User'>
+}
+
+interface EntityArchiveEventSysProps {
+  archivedAt: string
+  firstPublishedAt?: string
+  archivedBy: Link<'User'>
+  archivedVersion: number
+}
+
+interface BaseEntityPublishEventSys<T extends 'Entry' | 'Asset' | 'ContentType'> {
+  type: T
+  id: string
+  space: Link<'Space'>
+  environment: Link<'Environment'>
+  createdBy: Link<'User'>
+  updatedBy: Link<'User'>
+  revision: number
+  createdAt: string
+  updatedAt: string
+  publishedVersion: number
+}
+
+interface BaseEntityDeleteEventSys<T extends 'Entry' | 'Asset' | 'ContentType'> {
+  type: T
+  id: string
+  space: Link<'Space'>
+  environment: Link<'Environment'>
+  revision: number
+  createdAt: string
+  updatedAt: string
+  deletedAt: string
+  deletedBy: Link<'User'>
+}
+
+/* Entries */
+
+interface BaseEntryEventPayload {
+  metadata: Metadata
+  fields: EntryFields
+}
+
+interface EntryFields {
+  [fieldName: string]: {
+    [locale: string]: string
+  }
+}
+
+interface BasePublishableEntrySys extends BasePublishableDeliveryEntitySys<'Entry'> {
+  contentType: Link<'ContentType'>
+}
+
+export interface EntryCreateEventPayload extends BaseEntryEventPayload {
+  sys: BasePublishableEntrySys
+}
+
+export interface EntryAutosaveEventPayload extends BaseEntryEventPayload {
+  sys: BasePublishableEntrySys | (BasePublishableEntrySys & PublishedEntityAutosaveEventSysProps)
+}
+
+export type EntrySaveEventPayload = EntryAutosaveEventPayload
+
+interface EntryPublishedEventSys extends BaseEntityPublishEventSys<'Entry'> {
+  contentType: Link<'ContentType'>
+}
+
+export interface EntryPublishEventPayload extends BaseEntryEventPayload {
+  sys: EntryPublishedEventSys
+}
+
+interface EntryDeleteEventSys extends BaseEntityDeleteEventSys<'Entry'> {
+  contentType: Link<'ContentType'>
+}
+
+export interface EntryDeleteEventPayload {
+  sys: EntryDeleteEventSys
+}
+
+export type EntryUnpublishEventPayload = EntryDeleteEventPayload
+
+export interface EntryArchiveEventPayload extends BaseEntryEventPayload {
+  sys: BasePublishableEntrySys & EntityArchiveEventSysProps
+}
+
+export interface EntryUnarchiveEventPayload extends BaseEntryEventPayload {
+  sys: BasePublishableEntrySys & { fistPublishedAt?: string }
+}
+
+/* Assets */
+
+interface AssetFields {
+  title: {
+    [locale: string]: string
+  }
+  description: {
+    [locale: string]: string
+  }
+  file: {
+    [locale: string]: {
+      fileName: string
+      uploadFrom: Link<'Upload'>
+      contentType: string
+    }
+  }
+}
+
+export interface AssetCreateEventPayload {
+  metadata: Metadata
+  sys: BasePublishableDeliveryEntitySys<'Asset'>
+  fields: AssetFields
+}
+
+export interface AssetAutosaveEventPayload {
+  metadata: Metadata
+  sys:
+    | BasePublishableDeliveryEntitySys<'Asset'>
+    | (BasePublishableDeliveryEntitySys<'Asset'> & PublishedEntityAutosaveEventSysProps)
+  fields: AssetFields
+}
+
+export type AssetSaveEventPayload = AssetAutosaveEventPayload
+
+export interface AssetPublishEventPayload {
+  metadata: Metadata
+  sys: BaseEntityPublishEventSys<'Asset'>
+  fields: AssetFields
+}
+
+export interface AssetDeleteEventPayload {
+  sys: BaseEntityDeleteEventSys<'Asset'>
+}
+
+export type AssetUnpublishEventPayload = AssetDeleteEventPayload
+
+export interface AssetArchiveEventPayload {
+  metadata: Metadata
+  sys: BasePublishableDeliveryEntitySys<'Asset'> & EntityArchiveEventSysProps
+  fields: AssetFields
+}
+
+export interface AssetUnarchiveEventPayload {
+  metadata: Metadata
+  sys: BasePublishableDeliveryEntitySys<'Asset'> & { fistPublishedAt?: string }
+  fields: AssetFields
+}
+
+/* Content Types */
+
+type ContentTypeFields = {
+  id: string
+  name: string
+  type: string
+  localized: boolean
+  required: boolean
+  validations: ContentTypeFieldValidation[]
+  disabled: boolean
+  omitted: boolean
+}[]
+
+interface BaseContentTypePayload {
+  displayField: string
+  name: string
+  description: string
+  fields: ContentTypeFields
+}
+
+export interface ContentTypeCreateEventPayload extends BaseContentTypePayload {
+  sys: BasePublishableEntitySys<'ContentType'>
+}
+
+export interface ContentTypeSaveEventPayload extends BaseContentTypePayload {
+  sys:
+    | BasePublishableEntitySys<'ContentType'>
+    | (BasePublishableEntitySys<'ContentType'> & PublishedEntityAutosaveEventSysProps)
+}
+
+export interface ContentTypePublishEventPayload extends BaseContentTypePayload {
+  sys: BaseEntityPublishEventSys<'ContentType'>
+}
+
+export interface ContentTypeDeleteEventPayload {
+  sys: BaseEntityDeleteEventSys<'ContentType'>
+}
+
+export type ContentTypeUnpublishEventPayload = ContentTypeDeleteEventPayload
+
+/* Comments */
+
+interface BaseCommentTaskEventSys {
+  idempotencyId: string
+  user: Link<'User'>
+  environment: Link<'Environment'>
+  organization: Link<'Organization'>
+  space: Link<'Space'>
+}
+
+export interface CreateCommentEventPayload {
+  sys: BaseCommentTaskEventSys & {
+    newComment: CommentProps
+  }
+  userAgent: string
+}
+
+export interface DeleteCommentEventPayload {
+  sys: BaseCommentTaskEventSys & {
+    oldComment: CommentProps
+  }
+  userAgent: string
+}
+
+/* Tasks */
+
+export interface CreateTaskEventPayload {
+  sys: BaseCommentTaskEventSys & {
+    newTask: TaskProps
+  }
+  userAgent: string
+}
+
+export interface SaveTaskEventPayload {
+  sys: BaseCommentTaskEventSys & {
+    oldTask: TaskProps
+    newTask: TaskProps
+  }
+  userAgent: string
+}
+
+export interface DeleteTaskEventPayload {
+  sys: BaseCommentTaskEventSys & {
+    oldTask: TaskProps
+  }
+  userAgent: string
+}

--- a/src/requests/typings/function.ts
+++ b/src/requests/typings/function.ts
@@ -84,6 +84,54 @@ type AppEventBase<
     | FunctionTypeEnum.APP_EVENT_FILTER
 }
 
+export type AppEventContentType = {
+  [A in AppEventEntityActions<'ContentType'>]: AppEventBase<'ContentType', A>
+}[AppEventEntityActions<'ContentType'>]
+
+export type AppEventEntry = {
+  [A in AppEventEntityActions<'Entry'>]: AppEventBase<'Entry', A>
+}[AppEventEntityActions<'Entry'>]
+
+export type AppEventAsset = {
+  [A in AppEventEntityActions<'Asset'>]: AppEventBase<'Asset', A>
+}[AppEventEntityActions<'Asset'>]
+
+export type AppEventAppInstallation = {
+  [A in AppEventEntityActions<'AppInstallation'>]: AppEventBase<'AppInstallation', A>
+}[AppEventEntityActions<'AppInstallation'>]
+
+export type AppEventTask = {
+  [A in AppEventEntityActions<'Task'>]: AppEventBase<'Task', A>
+}[AppEventEntityActions<'Task'>]
+
+export type AppEventComment = {
+  [A in AppEventEntityActions<'Comment'>]: AppEventBase<'Comment', A>
+}[AppEventEntityActions<'Comment'>]
+
+export type AppEventRelease = {
+  [A in AppEventEntityActions<'Release'>]: AppEventBase<'Release', A>
+}[AppEventEntityActions<'Release'>]
+
+export type AppEventReleaseAction = {
+  [A in AppEventEntityActions<'ReleaseAction'>]: AppEventBase<'ReleaseAction', A>
+}[AppEventEntityActions<'ReleaseAction'>]
+
+export type AppEventScheduledAction = {
+  [A in AppEventEntityActions<'ScheduledAction'>]: AppEventBase<'ScheduledAction', A>
+}[AppEventEntityActions<'ScheduledAction'>]
+
+export type AppEventBulkAction = {
+  [A in AppEventEntityActions<'BulkAction'>]: AppEventBase<'BulkAction', A>
+}[AppEventEntityActions<'BulkAction'>]
+
+export type AppEventTemplateInstallation = {
+  [A in AppEventEntityActions<'TemplateInstallation'>]: AppEventBase<'TemplateInstallation', A>
+}[AppEventEntityActions<'TemplateInstallation'>]
+
+export type AppEventWorkflow = {
+  [A in AppEventEntityActions<'Workflow'>]: AppEventBase<'Workflow', A>
+}[AppEventEntityActions<'Workflow'>]
+
 export type AppEventRequest = {
   [T in AppEventEntityName]: {
     [A in AppEventEntityActions<T>]: AppEventBase<T, A>

--- a/src/requests/typings/function.ts
+++ b/src/requests/typings/function.ts
@@ -2,40 +2,29 @@
 // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/ROADMAP.md
 /*eslint-disable no-unused-vars*/
 
+import { AppActionCategoryType, PlainClientAPI } from 'contentful-management'
+import { AppActionCategoryBodyMap, AppActionRequestBody } from './appAction'
+import { AppEventPayloadMap } from './event-payloads'
 import {
-  AppActionCategoryType,
-  AppInstallationProps,
-  AssetProps,
-  BulkActionProps,
-  CommentProps,
-  ContentTypeProps,
-  EntryProps,
-  EnvironmentTemplateInstallationProps,
-  PlainClientAPI,
-  ReleaseActionProps,
-  ReleaseProps,
-  ScheduledActionProps,
-  TaskProps,
-} from 'contentful-management'
-import {
-  RESOURCES_SEARCH_EVENT,
-  RESOURCES_LOOKUP_EVENT,
   type ResourcesLookupRequest,
   type ResourcesLookupResponse,
   type ResourcesSearchRequest,
   type ResourcesSearchResponse,
 } from './resources'
-import { AppActionCategoryBodyMap, AppActionRequestBody } from './appAction'
 
-const GRAPHQL_FIELD_MAPPING_EVENT = 'graphql.field.mapping'
-const GRAPHQL_QUERY_EVENT = 'graphql.query'
-const APP_EVENT_FILTER = 'appevent.filter'
-const APP_EVENT_HANDLER = 'appevent.handler'
-const APP_EVENT_TRANSFORMATION = 'appevent.transformation'
-const APP_ACTION_CALL = 'appaction.call'
+export enum FunctionTypeEnum {
+  GRAPHQL_FIELD_MAPPING = 'graphql.field.mapping',
+  GRAPHQL_QUERY = 'graphql.query',
+  APP_EVENT_FILTER = 'appevent.filter',
+  APP_EVENT_HANDLER = 'appevent.handler',
+  APP_EVENT_TRANSFORMATION = 'appevent.transformation',
+  APP_ACTION_CALL = 'appaction.call',
+  RESOURCES_SEARCH = 'resources.search',
+  RESOURCES_LOOKUP = 'resources.lookup',
+}
 
 type GraphQLFieldTypeMappingRequest = {
-  type: typeof GRAPHQL_FIELD_MAPPING_EVENT
+  type: FunctionTypeEnum.GRAPHQL_FIELD_MAPPING
   fields: { contentTypeId: string; field: Field }[]
 }
 
@@ -58,7 +47,7 @@ export type GraphQLFieldTypeMapping = {
 }
 
 type GraphQLQueryRequest = {
-  type: typeof GRAPHQL_QUERY_EVENT
+  type: FunctionTypeEnum.GRAPHQL_QUERY
   query: string
   isIntrospectionQuery: boolean
   variables: Record<string, unknown>
@@ -74,80 +63,32 @@ export type GraphQLQueryResponse = {
   extensions?: Record<string, unknown>
 }
 
-type ContentTypeActions = 'create' | 'save' | 'publish' | 'unpublish' | 'delete'
-type EntryActions =
-  | 'create'
-  | 'save'
-  | 'auto_save'
-  | 'publish'
-  | 'unpublish'
-  | 'archive'
-  | 'unarchive'
-  | 'delete'
-type AssetActions =
-  | 'create'
-  | 'save'
-  | 'auto_save'
-  | 'publish'
-  | 'unpublish'
-  | 'archive'
-  | 'unarchive'
-  | 'delete'
-type AppInstallationActions = 'create' | 'save' | 'delete'
-type TaskActions = 'create' | 'save' | 'delete'
-type CommentActions = 'create' | 'delete'
-type ReleaseActions = 'create' | 'save' | 'delete'
-type ReleaseActionActions = 'create' | 'execute'
-type ScheduledActionActions = 'create' | 'save' | 'delete' | 'execute'
-type BulkActionActions = 'create' | 'execute'
-type TemplateInstallationActions = 'complete'
+type AppEventEntityName = keyof AppEventPayloadMap
+type AppEventEntityActions<T extends AppEventEntityName> = keyof AppEventPayloadMap[T] & string
+type AppEventEntityPayload<
+  T extends AppEventEntityName,
+  A extends AppEventEntityActions<T>,
+> = AppEventPayloadMap[T][A]
 
-type AppEventBase<EntityName extends string, EntityActions extends string, EntityProps> = {
+type AppEventBase<
+  EntityName extends AppEventEntityName,
+  EntityAction extends AppEventEntityActions<EntityName>,
+> = {
   headers: Record<string, string | number> & {
-    'X-Contentful-Topic': `ContentManagement.${EntityName}.${EntityActions}`
+    'X-Contentful-Topic': `ContentManagement.${EntityName}.${EntityAction}`
   }
-  body: EntityProps
-  type: typeof APP_EVENT_HANDLER | typeof APP_EVENT_TRANSFORMATION | typeof APP_EVENT_FILTER
+  body: AppEventEntityPayload<EntityName, EntityAction>
+  type:
+    | FunctionTypeEnum.APP_EVENT_HANDLER
+    | FunctionTypeEnum.APP_EVENT_TRANSFORMATION
+    | FunctionTypeEnum.APP_EVENT_FILTER
 }
-export type AppEventContentType = AppEventBase<'ContentType', ContentTypeActions, ContentTypeProps>
-export type AppEventEntry = AppEventBase<'Entry', EntryActions, EntryProps>
-export type AppEventAsset = AppEventBase<'Asset', AssetActions, AssetProps>
-export type AppEventAppInstallation = AppEventBase<
-  'AppInstallation',
-  AppInstallationActions,
-  AppInstallationProps
->
-export type AppEventTask = AppEventBase<'Task', TaskActions, TaskProps>
-export type AppEventComment = AppEventBase<'Comment', CommentActions, CommentProps>
-export type AppEventRelease = AppEventBase<'Release', ReleaseActions, ReleaseProps>
-export type AppEventReleaseAction = AppEventBase<
-  'ReleaseAction',
-  ReleaseActionActions,
-  ReleaseActionProps
->
-export type AppEventScheduledAction = AppEventBase<
-  'ScheduledAction',
-  ScheduledActionActions,
-  ScheduledActionProps
->
-export type AppEventBulkAction = AppEventBase<'BulkAction', BulkActionActions, BulkActionProps>
-export type AppEventTemplateInstallation = AppEventBase<
-  'TemplateInstallation',
-  TemplateInstallationActions,
-  EnvironmentTemplateInstallationProps
->
-export type AppEventRequest =
-  | AppEventEntry
-  | AppEventAsset
-  | AppEventContentType
-  | AppEventAppInstallation
-  | AppEventTask
-  | AppEventComment
-  | AppEventRelease
-  | AppEventReleaseAction
-  | AppEventScheduledAction
-  | AppEventBulkAction
-  | AppEventTemplateInstallation
+
+export type AppEventRequest = {
+  [T in AppEventEntityName]: {
+    [A in AppEventEntityActions<T>]: AppEventBase<T, A>
+  }[AppEventEntityActions<T>]
+}[AppEventEntityName]
 
 export type AppEventFilterResponse = {
   result: boolean
@@ -175,7 +116,7 @@ export type AppActionRequest<
 > = {
   headers: Record<string, string | number>
   body: CategoryType extends 'Custom' ? CustomCategoryBody : AppActionRequestBody<CategoryType>
-  type: typeof APP_ACTION_CALL
+  type: FunctionTypeEnum.APP_ACTION_CALL
 }
 
 export type AppActionResponse = void | Record<string, unknown>
@@ -198,35 +139,35 @@ type FunctionEventHandlers<
   T extends AppActionCategoryType = never,
   U extends AppActionRequestBody<T> = never,
 > = {
-  [GRAPHQL_FIELD_MAPPING_EVENT]: {
+  [FunctionTypeEnum.GRAPHQL_FIELD_MAPPING]: {
     event: GraphQLFieldTypeMappingRequest
     response: GraphQLFieldTypeMappingResponse
   }
-  [GRAPHQL_QUERY_EVENT]: {
+  [FunctionTypeEnum.GRAPHQL_QUERY]: {
     event: GraphQLQueryRequest
     response: GraphQLQueryResponse
   }
-  [APP_ACTION_CALL]: {
+  [FunctionTypeEnum.APP_ACTION_CALL]: {
     event: AppActionRequest<T, U>
     response: AppActionResponse
   }
-  [APP_EVENT_FILTER]: {
+  [FunctionTypeEnum.APP_EVENT_FILTER]: {
     event: AppEventRequest
     response: AppEventFilterResponse
   }
-  [APP_EVENT_HANDLER]: {
+  [FunctionTypeEnum.APP_EVENT_HANDLER]: {
     event: AppEventRequest
     response: AppEventHandlerResponse
   }
-  [APP_EVENT_TRANSFORMATION]: {
+  [FunctionTypeEnum.APP_EVENT_TRANSFORMATION]: {
     event: AppEventRequest
     response: AppEventTransformationResponse
   }
-  [RESOURCES_SEARCH_EVENT]: {
+  [FunctionTypeEnum.RESOURCES_SEARCH]: {
     event: ResourcesSearchRequest
     response: ResourcesSearchResponse
   }
-  [RESOURCES_LOOKUP_EVENT]: {
+  [FunctionTypeEnum.RESOURCES_LOOKUP]: {
     event: ResourcesLookupRequest
     response: ResourcesLookupResponse
   }

--- a/src/requests/typings/index.ts
+++ b/src/requests/typings/index.ts
@@ -1,4 +1,5 @@
 export * from './appAction'
+export * from './event-payloads'
 export * from './function'
 export * from './request'
 export * from './validators'

--- a/src/requests/typings/resources.ts
+++ b/src/requests/typings/resources.ts
@@ -1,6 +1,3 @@
-export const RESOURCES_SEARCH_EVENT = 'resources.search'
-export const RESOURCES_LOOKUP_EVENT = 'resources.lookup'
-
 export type ResourcesSearchRequest = {
   type: 'resources.search'
   resourceType: string

--- a/src/requests/typings/resources.ts
+++ b/src/requests/typings/resources.ts
@@ -1,5 +1,10 @@
+import { FunctionTypeEnum } from './function'
+
+export const RESOURCES_SEARCH_EVENT = FunctionTypeEnum.RESOURCES_SEARCH
+export const RESOURCES_LOOKUP_EVENT = FunctionTypeEnum.RESOURCES_LOOKUP
+
 export type ResourcesSearchRequest = {
-  type: 'resources.search'
+  type: FunctionTypeEnum.RESOURCES_SEARCH
   resourceType: string
   query?: string
   locale?: string
@@ -20,7 +25,7 @@ type Scalar = string | number | boolean
 
 export type ResourcesLookupRequest<L extends Record<string, Scalar[]> = Record<string, Scalar[]>> =
   {
-    type: 'resources.lookup'
+    type: FunctionTypeEnum.RESOURCES_LOOKUP
     lookupBy: L
     resourceType: string
     locale?: string


### PR DESCRIPTION
- each entity/action event payload type is now enumerated explicitly, rather than exposing a single type for each entity across all actions
<img width="714" alt="Screenshot 2025-03-05 at 11 24 21 AM" src="https://github.com/user-attachments/assets/74c0fc44-f346-4228-aa56-2491e101c8a0" />


- exports an enum for App Function event types
<img width="970" alt="Screenshot 2025-03-05 at 11 25 49 AM" src="https://github.com/user-attachments/assets/3f970296-6bca-4119-9cb3-feae8f8d907f" />
