### PR TITLE
feat[CNX-271]: adding additional types in context required for NER in…

### DIFF
--- a/src/requests/typings/function.ts
+++ b/src/requests/typings/function.ts
@@ -201,6 +201,9 @@ export type FunctionEventContext<P extends Record<string, any> = Record<string, 
   appInstallationParameters: P
   cmaClientOptions?: ClientOptions
   cma?: PlainClientAPI
+  originalRequest?: {
+    headers: Record<string, any>
+  }
 }
 
 /**


### PR DESCRIPTION
We have to somehow distinguish between CDA and graphql in NER in app function specifically for `lookupHandler`.
We are adding the below type to make sure we can differentiate if the request is coming from CDA/CPA.

```
originalRequest?: {
    headers: Record<string, any>
  }
 ```
 
Context we get from function API 
 
 ```
   "event": {
    "type": "resources.lookup",
    "resourceType": "MockShop:Product",
    "lookupBy": { "urns": ["gid://shopify/Product/7983602040854", "gid://shopify/Product/7983595388950"] },
    "limit": 1000
  },
  "context": {
    "spaceId": "f00h9rgirk2b",
    "environmentId": "6275f161-b2be-4cf2-ba5c-04f8ece63283",
    "environmentUuid": "6275f161-b2be-4cf2-ba5c-04f8ece63283",
    "requestId": "e0a9ae3f-0b0e-4b8e-ad24-8e2ac4d6df93",
    "organizationId": "00y2g65dGhRIi6Xu9X3UGy",
    "originalRequest": {
      "headers": {
        "x-contentful-request-id": "e0a9ae3f-0b0e-4b8e-ad24-8e2ac4d6df93",
        "x-contentful-host": "cdn.contentful.com",
        "accept": "*/*",
        "accept-encoding": "gzip, br",
        "user-agent": "insomnia/11.4.0",
        "x-forwarded-for": "213.10.127.95",
        "contentful-api": "cda",
        "cf-environment-id": "master",
        "cf-organization-id": "00y2g65dGhRIi6Xu9X3UGy",
        "cf-space-id": "f00h9rgirk2b"
      }
    },
    "appInstallationParameters": {},
    "appDefinitionId": "3ieR63GAbivgOrLB79PVtA",
    "appFunctionId": "MockShopTutorial"
  }
}
```
 
Dependent PR 
- https://github.com/contentful/apps/pull/10142