### PR TITLE
chore: add vault secrets

### DIFF
--- a/.github/workflows/pages-build-deployment.yml
+++ b/.github/workflows/pages-build-deployment.yml
@@ -9,14 +9,33 @@ on:
 permissions:
   contents: read
   pages: write
+  id-token: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Retrieve Secrets from Vault
+        id: vault
+        uses: hashicorp/vault-action@v3.4.0
+        with:
+          url: ${{ secrets.VAULT_URL }}
+          role: ${{ github.event.repository.name }}-github-action
+          method: jwt
+          path: github-actions
+          exportEnv: false
+          secrets: |
+            github/token/${{ github.event.repository.name }}-semantic-release token | GITHUB_TOKEN ;
+            secret/data/github/automation-app-user GH_USER_NAME | GIT_COMMITTER_NAME ;
+            secret/data/github/automation-app-user GH_USER_EMAIL | GIT_COMMITTER_EMAIL ;
+      
       - name: Checkout Repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
+          token: ${{ steps.vault.outputs.GITHUB_TOKEN }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v3
@@ -32,6 +51,6 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.vault.outputs.GITHUB_TOKEN }}
           publish_dir: ./docs
           publish_branch: gh-pages


### PR DESCRIPTION
# Purpose
Now that we have the automation bot deploying releases, we need to actually add the vault secrets so they can be used by the GH pages build deployment.