### PR TITLE
fix: prevent timing attacks with `===` [ES-71]

### DIFF
--- a/src/requests/timing-safe-string-equal.spec.ts
+++ b/src/requests/timing-safe-string-equal.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+
+import { timingSafeUtf8StringEqual } from './timing-safe-string-equal'
+
+describe('timingSafeUtf8StringEqual', () => {
+  const hex64 = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+
+  it('returns true for identical strings', () => {
+    expect(timingSafeUtf8StringEqual(hex64, hex64)).toBe(true)
+  })
+
+  it('returns false for same-length unequal strings', () => {
+    const other = '1123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+    expect(timingSafeUtf8StringEqual(hex64, other)).toBe(false)
+  })
+
+  it('returns false when lengths differ without throwing (timingSafeEqual guard)', () => {
+    expect(timingSafeUtf8StringEqual(hex64, hex64.slice(0, 63))).toBe(false)
+    expect(timingSafeUtf8StringEqual('', hex64)).toBe(false)
+    expect(timingSafeUtf8StringEqual(hex64, `${hex64}a`)).toBe(false)
+  })
+
+  it('is case-sensitive like string ===', () => {
+    expect(timingSafeUtf8StringEqual(hex64, hex64.toUpperCase())).toBe(false)
+  })
+})

--- a/src/requests/timing-safe-string-equal.ts
+++ b/src/requests/timing-safe-string-equal.ts
@@ -1,0 +1,13 @@
+import * as crypto from 'crypto'
+
+const textEncoder = new TextEncoder()
+
+/** Constant-time compare of UTF-8 bytes; preserves string `===` semantics (e.g. hex case). */
+export const timingSafeUtf8StringEqual = (a: string, b: string): boolean => {
+  const aBuf = textEncoder.encode(a)
+  const bBuf = textEncoder.encode(b)
+  if (aBuf.length !== bBuf.length) {
+    return false
+  }
+  return crypto.timingSafeEqual(aBuf, bBuf)
+}

--- a/src/requests/verify-request.spec.ts
+++ b/src/requests/verify-request.spec.ts
@@ -201,6 +201,15 @@ describe('verifyRequest', () => {
 
           expect(() => verifyRequest(VALID_SECRET, incomingRequest)).toThrow()
         })
+        it('throws when signature length is not 64 (before timing-safe compare)', () => {
+          const incomingRequest = makeIncomingRequest({}, makeContextHeaders(contextHeaders))
+
+          incomingRequest.headers[ContentfulHeader.Signature] = incomingRequest.headers[
+            ContentfulHeader.Signature
+          ].slice(0, 63)
+
+          expect(() => verifyRequest(VALID_SECRET, incomingRequest, 0)).toThrow()
+        })
         it('throws when missing timestamp', () => {
           const incomingRequest = makeIncomingRequest({}, makeContextHeaders(contextHeaders))
 

--- a/src/requests/verify-request.ts
+++ b/src/requests/verify-request.ts
@@ -10,6 +10,7 @@ import {
   ContentfulHeader,
 } from './typings'
 import { normalizeHeaders, pickHeaders } from './utils'
+import { timingSafeUtf8StringEqual } from './timing-safe-string-equal'
 import { signRequest } from './sign-request'
 import { ExpiredRequestException } from './exceptions'
 
@@ -83,5 +84,5 @@ export const verifyRequest = (
     timestamp,
   )
 
-  return signature === computedSignature
+  return timingSafeUtf8StringEqual(signature, computedSignature)
 }


### PR DESCRIPTION
Support Ticket: https://contentful.atlassian.net/jira/servicedesk/projects/ES/queues/custom/5835/board/7168?selectedIssue=ES-71

Prevents timing attacks by swapping out `===` for crypto safeString comparison. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR addresses a security vulnerability by implementing timing-safe string comparison to prevent timing attacks in request verification, as referenced in support ticket ES-71. It replaces the insecure `===` operator with a cryptographically secure constant-time comparison function.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Introduces timingSafeUtf8StringEqual function in timing-safe-string-equal.ts (CryptoModule) for constant-time string comparison to prevent timing attacks.</li>

<li>Replaces `signature === computedSignature` with timingSafeUtf8StringEqual in verify-request.ts to mitigate timing attack risks.</li>

<li>Adds comprehensive tests for the new timing-safe function in timing-safe-string-equal.spec.ts.</li>

<li>Adds test in verify-request.spec.ts to ensure signature length validation occurs before timing-safe comparison.</li>

</ul>
</details>

</div>