### PR TITLE
chore: set Backstage system to app-framework in catalog-info []

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -25,6 +25,6 @@ spec:
   type: library
   #deprecated, experimental, production, unknown
   lifecycle: production
-  system: unknown #optional
+  system: app-framework
   # your team name as it appears in github when tagging them for reviews
   owner: group:team-extensibility


### PR DESCRIPTION
## Summary

Adds `spec.system: app-framework` to `catalog-info.yaml` so this component is grouped under the correct system in the service catalog.

## Test plan

- [ ] No CI workflows depend on the previous `system` value.
 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR updates the Backstage catalog-info.yaml to set the correct system value for this component. The spec.system field is changed from 'unknown' to 'app-framework', which properly groups this library component under the app-framework system in the Backstage service catalog.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Updates spec.system from 'unknown' to 'app-framework' in catalog-info.yaml to correctly group this component under the app-framework system in Backstage</li>

</ul>
</details>

</div>