### PR TITLE
[NT-3357] fix: replace console.log with debug logger in createValidateStatusCode

### DIFF
--- a/src/utils/http.spec.ts
+++ b/src/utils/http.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { createValidateStatusCode, HttpError, Response } from '.'
+
+const makeResponse = (statusCode: number, body = '{"sys":{"type":"Error"}}') =>
+  ({ statusCode, body } as Response)
+
+describe('createValidateStatusCode', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns the response when status code is allowed', () => {
+    const validate = createValidateStatusCode([200, 201])
+    const response = makeResponse(201)
+    expect(validate(response)).toBe(response)
+  })
+
+  it('throws HttpError when status code is not allowed', () => {
+    const validate = createValidateStatusCode([201])
+    const response = makeResponse(404, '{"sys":{"type":"Error","id":"NotFound"}}')
+    expect(() => validate(response)).toThrow(HttpError)
+  })
+
+  it('does not write to stdout when throwing', () => {
+    const consoleSpy = vi.spyOn(console, 'log')
+    const validate = createValidateStatusCode([201])
+    try {
+      validate(makeResponse(404))
+    } catch {
+      // expected
+    }
+    expect(consoleSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/utils/http.spec.ts
+++ b/src/utils/http.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest'
 import { createValidateStatusCode, HttpError, Response } from '.'
 
 const makeResponse = (statusCode: number, body = '{"sys":{"type":"Error"}}') =>
-  ({ statusCode, body } as Response)
+  ({ statusCode, body }) as Response
 
 describe('createValidateStatusCode', () => {
   afterEach(() => {

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -11,7 +11,6 @@ export const createHttpClient = (configOverride: ExtendOptions = {}) => {
 
 export const createValidateStatusCode = (allowedStatusCodes: number[]) => (response: Response) => {
   if (!allowedStatusCodes.includes(response.statusCode)) {
-    console.log(response.body)
     throw new HTTPError(response)
   }
   return response

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,4 +1,7 @@
 import got, { ExtendOptions, Got, HTTPError, Response as GotResponse } from 'got'
+import { createLogger } from './logger'
+
+const log = createLogger({ namespace: 'utils/http' })
 
 const config = {
   prefixUrl: process.env.BASE_URL || 'https://api.contentful.com',
@@ -11,6 +14,7 @@ export const createHttpClient = (configOverride: ExtendOptions = {}) => {
 
 export const createValidateStatusCode = (allowedStatusCodes: number[]) => (response: Response) => {
   if (!allowedStatusCodes.includes(response.statusCode)) {
+    log(`unexpected status code %d: %s`, response.statusCode, response.body)
     throw new HTTPError(response)
   }
   return response


### PR DESCRIPTION
`createValidateStatusCode` unconditionally called console.log(response.body) before throwing HTTPError on any unexpected status code. This bypasses any structured logger in the consuming application and writes raw JSON directly to stdout.

In Grafana/Loki environments each line of the JSON body is ingested as a separate log entry at error level with no extractable message field, causing significant observability noise (e.g. 550k+ entries/month from 404s on deleted app installations in our Grafana).

Following review feedback, the console.log is replaced with the package's existing debug logger, gated behind `DEBUG=@contentful/node-apps-toolkit*`. This means it is silent by default in production but available for local debugging when needed.

This change also adds the first unit tests for `createValidateStatusCode`, including an explicit assertion that no stdout output occurs when the error path fires.