### PR TITLE
fix: bump form-data to 4.0.6 to clear CVE-2025-7783 [EXT-7482]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5194,16 +5194,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -5655,9 +5655,10 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },


### PR DESCRIPTION
[EXT-7482](https://contentful.atlassian.net/browse/EXT-7482) · tracked by [AIS-51](https://contentful.atlassian.net/browse/AIS-51)

## Summary
- Bumps the transitive `form-data` dependency from `4.0.5` to `4.0.6`, clearing the CRLF-injection advisory **GHSA-hmw2-7cc7-3qxx** (CVE-2025-7783 family, affected range `<4.0.6`).
- `form-data` is pulled in via `axios` (declared range `^4.0.5`, which already permits the fix). `npm update form-data --package-lock-only` resolves it forward — no `package.json` change.
- Minimal lockfile-only diff: only `form-data` and `hasown` change.

## Test plan
- [x] `npm ci` installs cleanly
- [x] `npm run build` passes (tsup)
- [x] `npm run test:unit` — 85 tests pass, 4/4 files (after `generate:key` fixture step)
- [x] `npm audit` confirms form-data advisory cleared
- [x] CI green

Generated with [Claude Code](https://claude.com/claude-code)

[EXT-7482]: https://contentful.atlassian.net/browse/EXT-7482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIS-51]: https://contentful.atlassian.net/browse/AIS-51?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ