### PR TITLE
feat: add shared App Action and Function manifest validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ consumed by Contentful apps, app backends, and third-party integrators — every
 | Token minting | `src/keys/get-management-token.ts` |
 | Request signing / verification | `src/requests/sign-request.ts`, `src/requests/verify-request.ts` |
 | Public type surface | `src/requests/typings/` |
+| Manifest validation rules | `src/validation/` |
 | Build config | `tsup.config.js`, subpath map in `package.json#exports` |
 | Release config | `.releaserc`, `.circleci/config.yml` |
 | Decision records | `docs/ADRs/` |
@@ -31,9 +32,20 @@ consumed by Contentful apps, app backends, and third-party integrators — every
 ## Guardrails
 
 - **This package is published publicly.** Anything exported from `src/index.ts`,
-  `src/keys/index.ts`, `src/requests/index.ts`, `src/requests/typings/index.ts` or
-  `src/utils/index.ts` is a public contract. Removing or renaming an export is a breaking
-  change and must be released as one (`BREAKING CHANGE:` footer).
+  `src/keys/index.ts`, `src/requests/index.ts`, `src/requests/typings/index.ts`,
+  `src/utils/index.ts` or `src/validation/index.ts` is a public contract. Removing or
+  renaming an export is a breaking change and must be released as one
+  (`BREAKING CHANGE:` footer).
+- **A validation rule in `src/validation/` is a published contract in both directions.**
+  Loosening a rule is a `fix`; making one *stricter* rejects manifests that used to be
+  accepted and is breaking, even though no export changed name. These rules are consumed by
+  both the app CLI and the service that validates the same manifest on upload — the whole
+  point is that the two agree, so a change here must land in lockstep with a version bump in
+  every consumer, never in one alone. Each rule is exported twice on purpose: as a `*_PATTERN`
+  string for consumers that compose JSON Schema, and as an `isValid*` predicate for consumers
+  that validate imperatively. Keep both in step, and keep the patterns engine-agnostic
+  strings — no validation library belongs in this package's dependencies. See
+  [`docs/ADRs/2026-09-09-app-manifest-validation-shipped-from-the-root-entry-point.md`](./docs/ADRs/2026-09-09-app-manifest-validation-shipped-from-the-root-entry-point.md).
 - **Do not weaken the crypto paths.** `verifyRequest` compares signatures with
   `timingSafeUtf8StringEqual` (`crypto.timingSafeEqual`), never `===`. See
   [`docs/ADRs/2026-03-24-constant-time-signature-comparison.md`](./docs/ADRs/2026-03-24-constant-time-signature-comparison.md).

--- a/docs/ADRs/2026-09-09-app-manifest-validation-shipped-from-the-root-entry-point.md
+++ b/docs/ADRs/2026-09-09-app-manifest-validation-shipped-from-the-root-entry-point.md
@@ -1,0 +1,62 @@
+# Ship app manifest validation from the root entry point, as patterns plus predicates
+
+- **Date:** 2026-09-09
+- **Commit:** `feat(validation): add shared App Action and Function manifest validation`
+
+## Status
+
+Accepted.
+
+## Context
+
+The rules that decide whether an app manifest is valid — what an `allowNetworks` entry may
+look like, how long an App Action `id` may be, which extensions a hosted code `path` may
+end in, which event topics a Function may accept — were implemented twice: once in the CLI
+that validates a manifest before upload, and once in the service that validates the same
+manifest on receipt.
+
+The two copies drifted, and the drift was customer-visible. A wildcard domain with more
+than one subdomain label (e.g. `*.eu.example.com`) was rejected because one copy's wildcard
+branch matched a single label where the other allowed any number. A
+hosted code path's extension separator was an unescaped `.`, so a path with no separator
+at all was accepted. Each fix had to be made, reviewed and released twice, and nothing
+prevented the next divergence.
+
+Two consumers need the same rules in two different shapes: one composes JSON Schema and
+needs the raw `pattern` string and the numeric bounds as data; the other validates
+imperatively and needs a callable predicate.
+
+## Decision
+
+Put the rules in this package, in `src/validation/`, and export each one as **both** a
+pattern string (or constant) and a predicate.
+
+- **Both shapes, one source.** `NETWORK_ADDRESS_PATTERN` is the string a schema embeds;
+  `isValidNetworkAddress` is the predicate a script calls, and it compiles that same
+  pattern. Neither consumer reimplements the rule, and neither has to adapt to the other's
+  validation engine. Patterns stay engine-agnostic strings for exactly this reason — no
+  validation library appears in this package's dependencies.
+- **Exported from the root entry point**, not only the `./validation` subpath. A subpath
+  export resolves only under `moduleResolution` `node16`/`nodenext`/`bundler`; a consumer
+  on `node` (node10) resolution cannot see it at all, and gets `TS2307` with no runtime
+  error to explain it. The subpath is still declared for consumers who prefer it.
+- **`FUNCTION_EVENT_TYPES` is derived from `FunctionTypeEnum`**, via `Object.values`, rather
+  than declared as a second list of the same nine topics. The enum already existed here and
+  is the named-topic surface; the derived array is the same values as data, for building a
+  schema `enum` or checking membership. A spec asserts the two agree, so adding a topic to
+  the enum cannot leave the array behind.
+
+## Consequences
+
+**Enables:** a validation rule is fixed once and both consumers pick it up on a version
+bump. Backend and CLI cannot disagree about whether a manifest is valid, so a manifest that
+passes locally is not rejected on upload.
+
+**Trade-off:** this is now a published contract. A rule that gets *stricter* rejects input
+that used to be accepted, which is breaking for consumers even though no export changed
+name — it needs a major release, and tightening a bound is not a `fix`. Every rule also
+carries a boundary spec, because a regression here is silent until a customer hits it.
+
+**Deliberately not done:** the predicates are not schema objects from a validation library.
+Adding one would force it on every consumer of this package, including those that only mint
+a token, and would still not serve the consumer whose schema engine differs.

--- a/docs/ADRs/README.md
+++ b/docs/ADRs/README.md
@@ -9,6 +9,7 @@ Add a new record as `YYYY-MM-DD-short-title.md` using the same
 
 | Date | Status | Title |
 | --- | --- | --- |
+| 2026-09-09 | Accepted | [Ship app manifest validation from the root entry point, as patterns plus predicates](./2026-09-09-app-manifest-validation-shipped-from-the-root-entry-point.md) |
 | 2026-08-24 | Accepted | [Separate generated API docs from tracked decision records](./2026-08-24-separate-generated-docs-from-decision-records.md) |
 | 2026-05-18 | Accepted | [Keep `contentful-management` as a type-only dependency (and follow its Node floor)](./2026-05-18-contentful-management-v12-as-a-type-only-dependency.md) |
 | 2026-03-24 | Accepted | [Compare request signatures in constant time](./2026-03-24-constant-time-signature-comparison.md) |

--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
     "./utils": {
       "import": "./lib/utils/index.mjs",
       "require": "./lib/utils/index.cjs"
+    },
+    "./validation": {
+      "import": "./lib/validation/index.mjs",
+      "require": "./lib/validation/index.cjs"
     }
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -10,26 +10,32 @@
   ],
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./lib/index.mjs",
       "require": "./lib/index.cjs"
     },
     "./keys": {
+      "types": "./lib/keys/index.d.ts",
       "import": "./lib/keys/index.mjs",
       "require": "./lib/keys/index.cjs"
     },
     "./requests": {
+      "types": "./lib/requests/index.d.ts",
       "import": "./lib/requests/index.mjs",
       "require": "./lib/requests/index.cjs"
     },
     "./requests/typings": {
+      "types": "./lib/requests/typings/index.d.ts",
       "import": "./lib/requests/typings/index.mjs",
       "require": "./lib/requests/typings/index.cjs"
     },
     "./utils": {
+      "types": "./lib/utils/index.d.ts",
       "import": "./lib/utils/index.mjs",
       "require": "./lib/utils/index.cjs"
     },
     "./validation": {
+      "types": "./lib/validation/index.d.ts",
       "import": "./lib/validation/index.mjs",
       "require": "./lib/validation/index.cjs"
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { getManagementToken } from './keys'
 export * from './requests'
+export * from './validation'

--- a/src/validation/action-id.spec.ts
+++ b/src/validation/action-id.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { isValidActionId, MAX_ACTION_ID_LENGTH } from './action-id'
+
+describe('isValidActionId', () => {
+  it('accepts an alphanumeric id', () => {
+    expect(isValidActionId('myAction123')).toBe(true)
+  })
+
+  it('rejects an id with non-alphanumeric characters', () => {
+    expect(isValidActionId('my-action')).toBe(false)
+    expect(isValidActionId('my_action')).toBe(false)
+    expect(isValidActionId('my action')).toBe(false)
+  })
+
+  it('rejects an empty id', () => {
+    expect(isValidActionId('')).toBe(false)
+  })
+
+  it('accepts an id at the maximum length', () => {
+    expect(isValidActionId('a'.repeat(MAX_ACTION_ID_LENGTH))).toBe(true)
+  })
+
+  it('rejects an id exceeding the maximum length', () => {
+    expect(isValidActionId('a'.repeat(MAX_ACTION_ID_LENGTH + 1))).toBe(false)
+  })
+})

--- a/src/validation/action-id.ts
+++ b/src/validation/action-id.ts
@@ -1,0 +1,26 @@
+/**
+ * Pattern for the `id` of a hosted or function-backed App Action.
+ *
+ * Exported as a pattern string so it can be embedded directly in a JSON
+ * Schema `pattern` keyword.
+ *
+ * @category Validation
+ */
+export const ACTION_ID_PATTERN = '^[a-zA-Z0-9]+$'
+
+/** @category Validation */
+export const MIN_ACTION_ID_LENGTH = 1
+
+/** @category Validation */
+export const MAX_ACTION_ID_LENGTH = 64
+
+/**
+ * Returns whether a string is a valid App Action `id`.
+ *
+ * @category Validation
+ */
+export const isValidActionId = (id: string): boolean =>
+  typeof id === 'string' &&
+  id.length >= MIN_ACTION_ID_LENGTH &&
+  id.length <= MAX_ACTION_ID_LENGTH &&
+  new RegExp(ACTION_ID_PATTERN).test(id)

--- a/src/validation/action-parameters.spec.ts
+++ b/src/validation/action-parameters.spec.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ActionParameterDefinition,
+  MAX_PARAMETER_DEFAULT_STRING_LENGTH,
+  MAX_PARAMETER_DESCRIPTION_LENGTH,
+  MAX_PARAMETER_ID_LENGTH,
+  MAX_PARAMETER_NAME_LENGTH,
+  MAX_PARAMETER_OPTIONS,
+  MAX_PARAMETER_OPTION_LABEL_LENGTH,
+  validateActionParameter,
+} from './action-parameters'
+
+const validParameter: ActionParameterDefinition = {
+  id: 'param1',
+  name: 'Parameter 1',
+  type: 'Symbol',
+}
+
+describe('validateActionParameter', () => {
+  it('returns no errors for a minimal valid parameter', () => {
+    expect(validateActionParameter(validParameter)).toEqual([])
+  })
+
+  it('returns no errors when every optional field is present and valid', () => {
+    expect(
+      validateActionParameter({
+        ...validParameter,
+        description: 'What this parameter does',
+        required: true,
+        default: 'a default',
+      }),
+    ).toEqual([])
+  })
+
+  it('accepts a parameter with no "required" field', () => {
+    // contentful-management treats "required" as optional; requiring it here
+    // would reject manifests the API itself accepts.
+    expect(validateActionParameter(validParameter)).toEqual([])
+  })
+
+  describe('id', () => {
+    it('rejects an id that starts with a number', () => {
+      expect(validateActionParameter({ ...validParameter, id: '1param' })).toHaveLength(1)
+    })
+
+    it('rejects an id with an unsupported delimiter', () => {
+      expect(validateActionParameter({ ...validParameter, id: 'my-param' })).toHaveLength(1)
+    })
+
+    it('accepts an id using "_" as a delimiter', () => {
+      expect(validateActionParameter({ ...validParameter, id: 'my_param' })).toEqual([])
+    })
+
+    it('rejects an empty id', () => {
+      expect(validateActionParameter({ ...validParameter, id: '' })).toHaveLength(1)
+    })
+
+    it('accepts an id at the maximum length', () => {
+      const id = `a${'b'.repeat(MAX_PARAMETER_ID_LENGTH - 1)}`
+      expect(validateActionParameter({ ...validParameter, id })).toEqual([])
+    })
+
+    it('rejects an id exceeding the maximum length', () => {
+      const id = `a${'b'.repeat(MAX_PARAMETER_ID_LENGTH)}`
+      expect(validateActionParameter({ ...validParameter, id })).toHaveLength(1)
+    })
+  })
+
+  describe('name', () => {
+    it('rejects an empty name', () => {
+      expect(validateActionParameter({ ...validParameter, name: '' })).toHaveLength(1)
+    })
+
+    it('accepts a name at the maximum length', () => {
+      const name = 'a'.repeat(MAX_PARAMETER_NAME_LENGTH)
+      expect(validateActionParameter({ ...validParameter, name })).toEqual([])
+    })
+
+    it('rejects a name exceeding the maximum length', () => {
+      const name = 'a'.repeat(MAX_PARAMETER_NAME_LENGTH + 1)
+      expect(validateActionParameter({ ...validParameter, name })).toHaveLength(1)
+    })
+  })
+
+  describe('description', () => {
+    it('accepts a description at the maximum length', () => {
+      const description = 'a'.repeat(MAX_PARAMETER_DESCRIPTION_LENGTH)
+      expect(validateActionParameter({ ...validParameter, description })).toEqual([])
+    })
+
+    it('rejects a description exceeding the maximum length', () => {
+      const description = 'a'.repeat(MAX_PARAMETER_DESCRIPTION_LENGTH + 1)
+      expect(validateActionParameter({ ...validParameter, description })).toHaveLength(1)
+    })
+  })
+
+  describe('type', () => {
+    it('accepts every supported type', () => {
+      for (const type of ['Boolean', 'Symbol', 'Number', 'Enum'] as const) {
+        expect(validateActionParameter({ ...validParameter, type })).toEqual([])
+      }
+    })
+
+    it('rejects an unsupported type', () => {
+      const parameter = { ...validParameter, type: 'Text' } as unknown as ActionParameterDefinition
+      expect(validateActionParameter(parameter)).toHaveLength(1)
+    })
+  })
+
+  describe('default', () => {
+    it('accepts a boolean, string or number default', () => {
+      expect(validateActionParameter({ ...validParameter, default: true })).toEqual([])
+      expect(validateActionParameter({ ...validParameter, default: 'text' })).toEqual([])
+      expect(validateActionParameter({ ...validParameter, default: 42 })).toEqual([])
+    })
+
+    it('rejects a default that is not a primitive', () => {
+      const parameter = {
+        ...validParameter,
+        default: { nested: true },
+      } as unknown as ActionParameterDefinition
+      expect(validateActionParameter(parameter)).toHaveLength(1)
+    })
+
+    it('rejects a string default exceeding the maximum length', () => {
+      const parameter = {
+        ...validParameter,
+        default: 'a'.repeat(MAX_PARAMETER_DEFAULT_STRING_LENGTH + 1),
+      }
+      expect(validateActionParameter(parameter)).toHaveLength(1)
+    })
+  })
+
+  describe('options', () => {
+    it('accepts string options', () => {
+      expect(validateActionParameter({ ...validParameter, options: ['one', 'two'] })).toEqual([])
+    })
+
+    it('accepts single-property object options', () => {
+      expect(validateActionParameter({ ...validParameter, options: [{ one: 'One' }] })).toEqual([])
+    })
+
+    it('rejects an empty options array', () => {
+      expect(validateActionParameter({ ...validParameter, options: [] })).toHaveLength(1)
+    })
+
+    it('rejects more options than the maximum', () => {
+      const options = Array.from({ length: MAX_PARAMETER_OPTIONS + 1 }, (_, i) => `option${i}`)
+      expect(validateActionParameter({ ...validParameter, options })).toHaveLength(1)
+    })
+
+    it('rejects an empty string option', () => {
+      expect(validateActionParameter({ ...validParameter, options: [''] })).toHaveLength(1)
+    })
+
+    it('rejects a string option exceeding the maximum label length', () => {
+      const options = ['a'.repeat(MAX_PARAMETER_OPTION_LABEL_LENGTH + 1)]
+      expect(validateActionParameter({ ...validParameter, options })).toHaveLength(1)
+    })
+
+    it('rejects an object option with more than one property', () => {
+      const options = [{ one: 'One', two: 'Two' }]
+      expect(validateActionParameter({ ...validParameter, options })).toHaveLength(1)
+    })
+  })
+
+  it('reports every problem at once rather than stopping at the first', () => {
+    const parameter = {
+      id: '1-bad',
+      name: '',
+      type: 'Text',
+    } as unknown as ActionParameterDefinition
+    expect(validateActionParameter(parameter).length).toBeGreaterThan(2)
+  })
+})

--- a/src/validation/action-parameters.ts
+++ b/src/validation/action-parameters.ts
@@ -1,0 +1,171 @@
+/**
+ * Pattern for an App Action parameter's `id`. It cannot start with a number
+ * and `_` is the only delimiter allowed, so a parameter stays reachable via
+ * dot notation in JavaScript.
+ *
+ * Exported as a pattern string so it can be embedded directly in a JSON
+ * Schema `pattern` keyword.
+ *
+ * @category Validation
+ */
+export const PARAMETER_ID_PATTERN = '^[a-zA-Z][a-zA-Z0-9_]*$'
+
+/** @category Validation */
+export const MAX_ACTION_NAME_LENGTH = 40
+
+/** @category Validation */
+export const MAX_ACTION_DESCRIPTION_LENGTH = 255
+
+/** @category Validation */
+export const MAX_ACTION_PARAMETERS = 8
+
+/** @category Validation */
+export const MIN_PARAMETER_ID_LENGTH = 1
+
+/** @category Validation */
+export const MAX_PARAMETER_ID_LENGTH = 64
+
+/** @category Validation */
+export const MIN_PARAMETER_NAME_LENGTH = 1
+
+/** @category Validation */
+export const MAX_PARAMETER_NAME_LENGTH = 64
+
+/** @category Validation */
+export const MAX_PARAMETER_DESCRIPTION_LENGTH = 255
+
+/** @category Validation */
+export const MAX_PARAMETER_DEFAULT_STRING_LENGTH = 255
+
+/** @category Validation */
+export const MIN_PARAMETER_OPTIONS = 1
+
+/** @category Validation */
+export const MAX_PARAMETER_OPTIONS = 1000
+
+/** @category Validation */
+export const MIN_PARAMETER_OPTION_LABEL_LENGTH = 1
+
+/** @category Validation */
+export const MAX_PARAMETER_OPTION_LABEL_LENGTH = 255
+
+/**
+ * The value types an App Action parameter can declare.
+ *
+ * @category Validation
+ */
+export const PARAMETER_TYPES = ['Boolean', 'Symbol', 'Number', 'Enum'] as const
+
+/** @category Validation */
+export type ParameterType = (typeof PARAMETER_TYPES)[number]
+
+type ActionParameterOption = string | Record<string, unknown>
+
+/**
+ * The shape of a single App Action parameter definition, as declared in an app
+ * manifest.
+ *
+ * @category Validation
+ */
+export interface ActionParameterDefinition {
+  id: string
+  name: string
+  description?: string
+  type: ParameterType
+  required?: boolean
+  default?: boolean | string | number
+  options?: ActionParameterOption[]
+}
+
+const isValidOption = (option: unknown): boolean => {
+  if (typeof option === 'string') {
+    return (
+      option.length >= MIN_PARAMETER_OPTION_LABEL_LENGTH &&
+      option.length <= MAX_PARAMETER_OPTION_LABEL_LENGTH
+    )
+  }
+  return typeof option === 'object' && option !== null && Object.keys(option).length === 1
+}
+
+/**
+ * Validates a single App Action parameter definition and returns a list of
+ * human-readable problems with it. An empty array means the parameter is
+ * valid.
+ *
+ * Returns every problem rather than throwing on the first, so a manifest can
+ * be reported on in full in one pass.
+ *
+ * @category Validation
+ */
+export const validateActionParameter = (parameter: ActionParameterDefinition): string[] => {
+  const errors: string[] = []
+
+  if (
+    typeof parameter.id !== 'string' ||
+    parameter.id.length < MIN_PARAMETER_ID_LENGTH ||
+    parameter.id.length > MAX_PARAMETER_ID_LENGTH ||
+    !new RegExp(PARAMETER_ID_PATTERN).test(parameter.id)
+  ) {
+    errors.push(
+      `Invalid parameter "id" (must start with a letter, contain only letters, numbers, and "_", and be at most ${MAX_PARAMETER_ID_LENGTH} characters). Received: ${parameter.id}.`,
+    )
+  }
+
+  if (
+    typeof parameter.name !== 'string' ||
+    parameter.name.length < MIN_PARAMETER_NAME_LENGTH ||
+    parameter.name.length > MAX_PARAMETER_NAME_LENGTH
+  ) {
+    errors.push(
+      `Invalid parameter "name" (must be ${MIN_PARAMETER_NAME_LENGTH}-${MAX_PARAMETER_NAME_LENGTH} characters). Received: ${parameter.name}.`,
+    )
+  }
+
+  if (
+    parameter.description !== undefined &&
+    (typeof parameter.description !== 'string' ||
+      parameter.description.length > MAX_PARAMETER_DESCRIPTION_LENGTH)
+  ) {
+    errors.push(
+      `Invalid parameter "description" (must be at most ${MAX_PARAMETER_DESCRIPTION_LENGTH} characters).`,
+    )
+  }
+
+  if (!PARAMETER_TYPES.includes(parameter.type)) {
+    errors.push(
+      `Invalid parameter "type" (must be one of ${PARAMETER_TYPES.join(', ')}). Received: ${parameter.type}.`,
+    )
+  }
+
+  if (parameter.default !== undefined) {
+    const defaultType = typeof parameter.default
+    if (defaultType !== 'boolean' && defaultType !== 'string' && defaultType !== 'number') {
+      errors.push('Invalid parameter "default" (must be a boolean, string, or number).')
+    } else if (
+      defaultType === 'string' &&
+      (parameter.default as string).length > MAX_PARAMETER_DEFAULT_STRING_LENGTH
+    ) {
+      errors.push(
+        `Invalid parameter "default" (string default must be at most ${MAX_PARAMETER_DEFAULT_STRING_LENGTH} characters).`,
+      )
+    }
+  }
+
+  if (parameter.options !== undefined) {
+    if (
+      !Array.isArray(parameter.options) ||
+      parameter.options.length < MIN_PARAMETER_OPTIONS ||
+      parameter.options.length > MAX_PARAMETER_OPTIONS
+    ) {
+      errors.push(
+        `Invalid parameter "options" (must be an array of ${MIN_PARAMETER_OPTIONS}-${MAX_PARAMETER_OPTIONS} items).`,
+      )
+    } else if (!parameter.options.every(isValidOption)) {
+      errors.push(
+        `Invalid parameter "options" (each item must be a non-empty string of at most ${MAX_PARAMETER_OPTION_LABEL_LENGTH} characters, or an object with exactly one property).`,
+      )
+    }
+  }
+
+  return errors
+}

--- a/src/validation/function-event-type.spec.ts
+++ b/src/validation/function-event-type.spec.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import {
+  FUNCTION_EVENT_TYPES,
+  isValidFunctionEventType,
+  type FunctionEventTopic,
+} from './function-event-type'
+import { FunctionTypeEnum } from '../requests/typings/function'
+
+describe('FUNCTION_EVENT_TYPES', () => {
+  it('holds exactly the values of FunctionTypeEnum', () => {
+    // The array is derived from the enum so the two cannot drift apart.
+    expect([...FUNCTION_EVENT_TYPES].sort()).toEqual([...Object.values(FunctionTypeEnum)].sort())
+  })
+})
+
+describe('FunctionEventTopic', () => {
+  it('accepts a plain string literal, unlike the enum itself', () => {
+    // A TypeScript enum is nominal for assignment: a bare 'appaction.call'
+    // does not satisfy FunctionTypeEnum, which breaks callers that read topics
+    // from a manifest or a database as plain strings. The template literal
+    // type stays in step with the enum while remaining structurally
+    // assignable. This asserts at compile time; the runtime check is
+    // incidental.
+    const fromManifest: FunctionEventTopic = 'graphql.field.mapping'
+    const accepts: FunctionEventTopic[] = ['graphql.field.mapping', 'graphql.query']
+    expect(fromManifest).toBe(FunctionTypeEnum.GraphqlFieldMapping)
+    expect(accepts).toHaveLength(2)
+  })
+
+  it('accepts an enum member too', () => {
+    const named: FunctionEventTopic = FunctionTypeEnum.AppActionCall
+    expect(named).toBe('appaction.call')
+  })
+
+  it('narrows an unknown string through the predicate', () => {
+    const raw: string = 'appevent.filter'
+    if (isValidFunctionEventType(raw)) {
+      const narrowed: FunctionEventTopic = raw
+      expect(narrowed).toBe(FunctionTypeEnum.AppEventFilter)
+    } else {
+      expect.unreachable('expected a known topic to narrow')
+    }
+  })
+})
+
+describe('isValidFunctionEventType', () => {
+  it('accepts every event type a Function can declare', () => {
+    for (const eventType of Object.values(FunctionTypeEnum)) {
+      expect(isValidFunctionEventType(eventType)).toBe(true)
+    }
+  })
+
+  it('accepts a known topic passed as a plain string', () => {
+    expect(isValidFunctionEventType('appaction.call')).toBe(true)
+  })
+
+  it('rejects an unknown event type', () => {
+    expect(isValidFunctionEventType('not.a.real.event')).toBe(false)
+    expect(isValidFunctionEventType('webhooks.rest')).toBe(false)
+  })
+
+  it('rejects an empty string', () => {
+    expect(isValidFunctionEventType('')).toBe(false)
+  })
+
+  it('rejects an enum key rather than its value', () => {
+    expect(isValidFunctionEventType('AppActionCall')).toBe(false)
+  })
+})

--- a/src/validation/function-event-type.ts
+++ b/src/validation/function-event-type.ts
@@ -1,0 +1,50 @@
+import { FunctionTypeEnum } from '../requests/typings/function'
+
+/**
+ * Every event topic a Contentful Function can accept, as a union of string
+ * literals.
+ *
+ * Expanded from {@link FunctionTypeEnum} with a template literal type, so it
+ * stays in step with the enum while remaining *structurally* assignable: a
+ * plain `'appaction.call'` satisfies this type, where it would not satisfy the
+ * enum itself. Use this to type data read from a manifest or a database, and
+ * the enum where a topic is named in code.
+ *
+ * Distinct from `FunctionEventType` in `./requests`, which is
+ * `keyof FunctionEventHandlers`. Because that map is keyed by computed enum
+ * members, `keyof` yields the nominal enum type and rejects plain strings —
+ * it types a handler's generic parameter, not data read from a manifest.
+ *
+ * @category Validation
+ */
+export type FunctionEventTopic = `${FunctionTypeEnum}`
+
+/**
+ * Every event topic a Contentful Function can accept, as a plain array of
+ * string values.
+ *
+ * Derived from {@link FunctionTypeEnum} so the two cannot drift: consumers that
+ * need the values as data (to build a JSON Schema `enum`, or to check
+ * membership) read them from here, and consumers that need a named topic keep
+ * referencing the enum member.
+ *
+ * Typed as {@link FunctionEventTopic}, not as the enum, so a schema built by
+ * mapping over these values describes plain strings — matching the data that
+ * actually arrives over the wire.
+ *
+ * @category Validation
+ */
+export const FUNCTION_EVENT_TYPES = Object.freeze(
+  Object.values(FunctionTypeEnum),
+) as readonly FunctionEventTopic[]
+
+/**
+ * Returns whether a string is an event topic a Contentful Function can accept.
+ *
+ * Narrows to {@link FunctionEventTopic} rather than the enum, so a validated
+ * string stays assignable without a cast.
+ *
+ * @category Validation
+ */
+export const isValidFunctionEventType = (value: string): value is FunctionEventTopic =>
+  (FUNCTION_EVENT_TYPES as readonly string[]).includes(value)

--- a/src/validation/function-id.spec.ts
+++ b/src/validation/function-id.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { isValidFunctionId, MAX_FUNCTION_ID_LENGTH } from './function-id'
+
+describe('isValidFunctionId', () => {
+  it('accepts an alphanumeric id', () => {
+    expect(isValidFunctionId('myFunction123')).toBe(true)
+  })
+
+  it('rejects an id with non-alphanumeric characters', () => {
+    expect(isValidFunctionId('my-function')).toBe(false)
+    expect(isValidFunctionId('my_function')).toBe(false)
+    expect(isValidFunctionId('my function')).toBe(false)
+  })
+
+  it('rejects an empty id', () => {
+    expect(isValidFunctionId('')).toBe(false)
+  })
+
+  it('accepts an id at the maximum length', () => {
+    expect(isValidFunctionId('a'.repeat(MAX_FUNCTION_ID_LENGTH))).toBe(true)
+  })
+
+  it('rejects an id exceeding the maximum length', () => {
+    expect(isValidFunctionId('a'.repeat(MAX_FUNCTION_ID_LENGTH + 1))).toBe(false)
+  })
+})

--- a/src/validation/function-id.ts
+++ b/src/validation/function-id.ts
@@ -1,0 +1,27 @@
+/**
+ * Pattern for a Contentful Function's `id`.
+ *
+ * Structurally identical to {@link ACTION_ID_PATTERN} today, but kept as its
+ * own export because a Function id and an App Action id are distinct concepts
+ * that may diverge independently.
+ *
+ * @category Validation
+ */
+export const FUNCTION_ID_PATTERN = '^[a-zA-Z0-9]+$'
+
+/** @category Validation */
+export const MIN_FUNCTION_ID_LENGTH = 1
+
+/** @category Validation */
+export const MAX_FUNCTION_ID_LENGTH = 64
+
+/**
+ * Returns whether a string is a valid Contentful Function `id`.
+ *
+ * @category Validation
+ */
+export const isValidFunctionId = (id: string): boolean =>
+  typeof id === 'string' &&
+  id.length >= MIN_FUNCTION_ID_LENGTH &&
+  id.length <= MAX_FUNCTION_ID_LENGTH &&
+  new RegExp(FUNCTION_ID_PATTERN).test(id)

--- a/src/validation/hosted-code-path.spec.ts
+++ b/src/validation/hosted-code-path.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { isValidHostedCodePath } from './hosted-code-path'
+
+describe('isValidHostedCodePath', () => {
+  it('accepts a .js path', () => {
+    expect(isValidHostedCodePath('functions/translate-entries.js')).toBe(true)
+  })
+
+  it('accepts a .mjs path', () => {
+    expect(isValidHostedCodePath('functions/translate-entries.mjs')).toBe(true)
+  })
+
+  it('accepts a path with dashes, underscores and nested folders', () => {
+    expect(isValidHostedCodePath('eins/zwei/trans-late_now.js')).toBe(true)
+  })
+
+  it('rejects a path where any character stands in for the extension dot', () => {
+    // Regression: an unescaped "." before "(m?js)" matched any single
+    // character, so a path with no literal dot was incorrectly accepted.
+    expect(isValidHostedCodePath('functions/translate-entriesXjs')).toBe(false)
+  })
+
+  it('rejects a path that does not end in .js or .mjs', () => {
+    expect(isValidHostedCodePath('functions/translate-entries.py')).toBe(false)
+  })
+
+  it('rejects a path with no extension', () => {
+    expect(isValidHostedCodePath('functions/translate-entries')).toBe(false)
+  })
+
+  it('rejects a path that does not start with a letter or number', () => {
+    expect(isValidHostedCodePath('_functions/eins.js')).toBe(false)
+    expect(isValidHostedCodePath('-functions/eins.js')).toBe(false)
+    expect(isValidHostedCodePath('/functions/zwei.js')).toBe(false)
+  })
+
+  it('rejects a path with unsupported characters', () => {
+    expect(isValidHostedCodePath('functions/no%no.js')).toBe(false)
+  })
+})

--- a/src/validation/hosted-code-path.ts
+++ b/src/validation/hosted-code-path.ts
@@ -1,0 +1,22 @@
+/**
+ * Pattern for the `path` of a hosted App Action or Contentful Function: it
+ * starts with a letter or number, may contain letters, numbers and the `/`,
+ * `_` and `-` delimiters, and ends in `.js` or `.mjs`.
+ *
+ * Exported as a pattern string so it can be embedded directly in a JSON
+ * Schema `pattern` keyword. The `.` before the extension is escaped — left
+ * unescaped it matches any character, accepting paths with no extension
+ * separator at all.
+ *
+ * @category Validation
+ */
+export const HOSTED_CODE_PATH_PATTERN = '^[a-zA-Z0-9][a-zA-Z0-9_/-]*\\.(m?js)$'
+
+/**
+ * Returns whether a string is a valid hosted App Action or Contentful
+ * Function `path`.
+ *
+ * @category Validation
+ */
+export const isValidHostedCodePath = (path: string): boolean =>
+  typeof path === 'string' && new RegExp(HOSTED_CODE_PATH_PATTERN).test(path)

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -1,0 +1,35 @@
+export { NETWORK_ADDRESS_PATTERN, isValidNetworkAddress } from './network-address'
+export {
+  ACTION_ID_PATTERN,
+  MIN_ACTION_ID_LENGTH,
+  MAX_ACTION_ID_LENGTH,
+  isValidActionId,
+} from './action-id'
+export {
+  FUNCTION_ID_PATTERN,
+  MIN_FUNCTION_ID_LENGTH,
+  MAX_FUNCTION_ID_LENGTH,
+  isValidFunctionId,
+} from './function-id'
+export { HOSTED_CODE_PATH_PATTERN, isValidHostedCodePath } from './hosted-code-path'
+export { FUNCTION_EVENT_TYPES, isValidFunctionEventType } from './function-event-type'
+export type { FunctionEventTopic } from './function-event-type'
+export {
+  PARAMETER_ID_PATTERN,
+  MAX_ACTION_NAME_LENGTH,
+  MAX_ACTION_DESCRIPTION_LENGTH,
+  MAX_ACTION_PARAMETERS,
+  MIN_PARAMETER_ID_LENGTH,
+  MAX_PARAMETER_ID_LENGTH,
+  MIN_PARAMETER_NAME_LENGTH,
+  MAX_PARAMETER_NAME_LENGTH,
+  MAX_PARAMETER_DESCRIPTION_LENGTH,
+  MAX_PARAMETER_DEFAULT_STRING_LENGTH,
+  MIN_PARAMETER_OPTIONS,
+  MAX_PARAMETER_OPTIONS,
+  MIN_PARAMETER_OPTION_LABEL_LENGTH,
+  MAX_PARAMETER_OPTION_LABEL_LENGTH,
+  PARAMETER_TYPES,
+  validateActionParameter,
+} from './action-parameters'
+export type { ParameterType, ActionParameterDefinition } from './action-parameters'

--- a/src/validation/network-address.spec.ts
+++ b/src/validation/network-address.spec.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { isValidNetworkAddress } from './network-address'
+
+describe('isValidNetworkAddress', () => {
+  it('accepts an IPv4 address', () => {
+    expect(isValidNetworkAddress('192.168.0.1')).toBe(true)
+  })
+
+  it('accepts an IPv4 address with a port', () => {
+    expect(isValidNetworkAddress('192.168.0.1:2000')).toBe(true)
+  })
+
+  it('rejects an IPv4 address with an octet above 255', () => {
+    expect(isValidNetworkAddress('427.0.0.1')).toBe(false)
+  })
+
+  it('accepts an IPv6 address', () => {
+    expect(isValidNetworkAddress('2001:0db8:85a3:0000:0000:8a2e:0370:7334')).toBe(true)
+  })
+
+  it('accepts a bracketed IPv6 address with a port', () => {
+    expect(isValidNetworkAddress('[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:443')).toBe(true)
+  })
+
+  it('accepts a domain', () => {
+    expect(isValidNetworkAddress('google.com')).toBe(true)
+  })
+
+  it('accepts a domain with a port', () => {
+    expect(isValidNetworkAddress('google.com:4000')).toBe(true)
+  })
+
+  it('rejects a string that is not an address at all', () => {
+    expect(isValidNetworkAddress('not an ip address')).toBe(false)
+  })
+
+  it('accepts a wildcard domain', () => {
+    expect(isValidNetworkAddress('*.cloudflare.com')).toBe(true)
+  })
+
+  it('accepts a wildcard domain with multiple subdomain labels', () => {
+    // Regression: the wildcard branch matched only a single subdomain label,
+    // rejecting real customer domains even though the non-wildcard branch
+    // already allowed any number of subdomains.
+    expect(isValidNetworkAddress('*.too.example.com')).toBe(true)
+    expect(isValidNetworkAddress('*.one.two.three.example.com')).toBe(true)
+  })
+
+  it('rejects a bare wildcard', () => {
+    expect(isValidNetworkAddress('*')).toBe(false)
+  })
+
+  it('rejects a wildcard with no domain label before the TLD', () => {
+    expect(isValidNetworkAddress('*.com')).toBe(false)
+  })
+
+  it('rejects a wildcard applied to an IP address', () => {
+    expect(isValidNetworkAddress('*.128.0.1')).toBe(false)
+  })
+
+  it('accepts a TLD longer than six characters', () => {
+    // ICANN has delegated long gTLDs since 2012; a shorter bound rejected
+    // valid customer addresses.
+    expect(isValidNetworkAddress('qa-gql-gateway.akzonobel.hosting')).toBe(true)
+    expect(isValidNetworkAddress('*.akzonobel.hosting')).toBe(true)
+  })
+
+  it('accepts a TLD at the maximum DNS label length of 63 characters', () => {
+    expect(isValidNetworkAddress(`example.${'a'.repeat(63)}`)).toBe(true)
+  })
+
+  it('rejects a TLD exceeding the maximum DNS label length of 63 characters', () => {
+    expect(isValidNetworkAddress(`example.${'a'.repeat(64)}`)).toBe(false)
+  })
+})

--- a/src/validation/network-address.ts
+++ b/src/validation/network-address.ts
@@ -1,0 +1,39 @@
+/**
+ * Pattern for a network address accepted in a Contentful Function or App
+ * Action's `allowNetworks` field: a domain, a wildcard domain, an IPv4
+ * address, or an IPv6 address, each with an optional port.
+ *
+ * Exported as a pattern string rather than a `RegExp` so it can be embedded
+ * directly in a JSON Schema `pattern` keyword by consumers that validate with
+ * a schema engine instead of a predicate.
+ *
+ * @category Validation
+ */
+export const NETWORK_ADDRESS_PATTERN =
+  '^(?:' + // Start of the non-capturing group for the entire address
+  '(?:' + // Start of the non-capturing group for domain names
+  '(?:\\*\\.)' + // Matches wildcard domains like *.example.com
+  '(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\\.)+' + // Matches one or more subdomains after the wildcard
+  '[a-zA-Z]{2,63}' + // Matches the top-level domain (TLD)
+  '|' + // OR
+  '(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\\.)+' + // Matches standard domains with one or more subdomains
+  '[a-zA-Z]{2,63}' + // Matches the top-level domain (TLD)
+  ')|' + // End of the non-capturing group for domain names, OR
+  '(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}' + // Matches the first three octets of an IPv4 address
+  '(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|' + // Matches the last octet of an IPv4 address
+  '(\\[(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}\\]' + // Matches IPv6 addresses in square brackets
+  '|(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4})' + // Matches IPv6 addresses without square brackets
+  ')(?::\\d{1,5})?$' // Matches an optional port number (1 to 5 digits)
+
+/**
+ * Returns whether a string is a valid entry for a Contentful Function or App
+ * Action's `allowNetworks` field.
+ *
+ * The TLD is bounded at 63 characters per RFC 1035 §2.3.4, the maximum length
+ * of a single DNS label. ICANN has delegated long gTLDs (`.hosting`,
+ * `.international`) since 2012, so a shorter bound rejects valid addresses.
+ *
+ * @category Validation
+ */
+export const isValidNetworkAddress = (address: string): boolean =>
+  typeof address === 'string' && new RegExp(NETWORK_ADDRESS_PATTERN).test(address)

--- a/tsup.config.js
+++ b/tsup.config.js
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 
 export default defineConfig({
-  entry: ['src/index.ts','src/keys/index.ts','src/requests/index.ts','src/requests/typings/index.ts','src/utils/index.ts'],
+  entry: ['src/index.ts','src/keys/index.ts','src/requests/index.ts','src/requests/typings/index.ts','src/utils/index.ts','src/validation/index.ts'],
   outDir: 'lib',
   format: ['cjs', 'esm'],
   dts: true,


### PR DESCRIPTION
## Summary

The rules that decide whether a Contentful App manifest is valid — what an `allowNetworks` entry may look like, how long an App Action `id` may be, which extensions a hosted code `path` may end in, which event topics a Function may accept — are currently implemented separately in the app CLI and in the API that validates the same manifest on upload. The two copies drifted, and the drift was user-visible: a wildcard domain with more than one subdomain label (`*.eu.example.com`) was rejected, and a hosted code path with no extension separator was accepted. This adds those rules here so both sides read one definition.

## Solution

- Add `src/validation/`, exporting each rule **twice**: a `*_PATTERN` string for consumers that compose JSON Schema, and an `isValid*` predicate for consumers that validate imperatively. Patterns stay plain strings, so no validation library enters this package's dependencies.
- Cover network addresses, App Action ids, Function ids, hosted code paths, action parameter definitions (with `validateActionParameter` returning every problem rather than throwing on the first), and Function event topics.
- Fix two bugs while consolidating: the wildcard branch of the network pattern now matches any number of subdomain labels, and the `.` before the code path extension is escaped so it no longer matches any character.
- Export from the **root entry point** as well as a `./validation` subpath — a subpath alone resolves only under `node16`/`nodenext`/`bundler` `moduleResolution`, so a consumer on node10 resolution cannot see it at all.
- Derive Function event topics from the existing `FunctionTypeEnum` rather than restating the same nine topics, with a spec asserting the two agree. They are exposed as `FunctionEventTopic`, a template literal union expanded from that enum, since an enum is nominal for assignment and a plain `'appaction.call'` read from a manifest would not satisfy the enum itself.
- Add an ADR recording the design, and note the new contract in `AGENTS.md`.

## Context

The TLD bound is 63 characters per RFC 1035 §2.3.4 (the maximum length of a single DNS label). ICANN has delegated long gTLDs such as `.hosting` since 2012, so the shorter bound some copies used rejected valid addresses.

`FunctionEventTopic` is deliberately **not** named `FunctionEventType`: that name already exists in `./requests` as `keyof FunctionEventHandlers`. Because that map is keyed by computed enum members, `keyof` yields the nominal enum type and rejects plain strings — it serves handler generics, not manifest data, so the two types are not interchangeable.

Worth a reviewer's attention: these rules are now a published contract in **both** directions. Loosening a rule is a `fix`, but making one *stricter* rejects manifests that used to be accepted and is breaking even though no export changes name. `AGENTS.md` records this.

Deliberately not done: the predicates are not schema objects from a validation library. Adding one would force it on every consumer of this package, including those that only mint a token, and still would not serve a consumer whose schema engine differs.

## Test plan

- [x] 67 new unit specs covering every rule, including boundary cases at and just past each length limit
- [x] Regression specs for both fixed bugs (multi-label wildcard domains; a path with any character standing in for the extension dot)
- [x] Spec asserting the derived topic array matches `FunctionTypeEnum` exactly, so the two cannot drift
- [x] Spec asserting `FunctionEventTopic` accepts a plain string literal, an enum member, and a value narrowed through the predicate
- [x] Full unit suite green (158 tests); `npm run lint` and prettier clean
- [x] `npm run build` produces `lib/validation/*` in both CJS and ESM with type declarations
- [x] Verified against a packed tarball that the root and `./validation` subpath both resolve at runtime in CJS and ESM, and that types resolve under `moduleResolution: node` as well as `node16`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
